### PR TITLE
CDC backbone: Postgres logical replication → Debezium → Redpanda

### DIFF
--- a/cdc/clean.sh
+++ b/cdc/clean.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+# Tear down the Debezium connector and the Postgres replication slot/publication
+# it created. Run this before `pnpm cdc:down` — deleting the connector does NOT
+# drop the slot, and a lingering slot pins WAL (disk grows until it's removed).
+set -e
+
+echo "→ deleting Debezium connector (if present)..."
+curl -s -X DELETE http://localhost:8083/connectors/owl-postgres >/dev/null 2>&1 || true
+
+# Let Postgres mark the slot inactive before we drop it.
+sleep 2
+
+# Connect to the dev DB via the host-exposed port using DATABASE_URL from .env
+# (strip the ?schema=public query, which psql does not accept).
+URL=$(grep -oE 'DATABASE_URL="?[^"]+' .env | sed -E 's/DATABASE_URL=//; s/"//g; s/\?.*//')
+
+echo "→ dropping replication slot + publication..."
+psql "$URL" \
+  -c "SELECT pg_drop_replication_slot('owl_cdc_slot') FROM pg_replication_slots WHERE slot_name = 'owl_cdc_slot';" \
+  -c "DROP PUBLICATION IF EXISTS owl_cdc_pub;"
+
+echo "✓ CDC cleanup done."

--- a/cdc/connectors/owl-postgres.template.json
+++ b/cdc/connectors/owl-postgres.template.json
@@ -1,0 +1,30 @@
+{
+  "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+  "tasks.max": "1",
+
+  "database.hostname": "db",
+  "database.port": "5432",
+  "database.user": "__POSTGRES_USER__",
+  "database.password": "__POSTGRES_PASSWORD__",
+  "database.dbname": "__POSTGRES_DB__",
+
+  "plugin.name": "pgoutput",
+  "slot.name": "owl_cdc_slot",
+  "publication.name": "owl_cdc_pub",
+  "publication.autocreate.mode": "filtered",
+
+  "topic.prefix": "owl",
+
+  "table.include.list": "public.Post,public.Like,public.UserFollows,public.Save,public.Repost,public.User",
+
+  "snapshot.mode": "no_data",
+
+  "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+  "key.converter.schemas.enable": "false",
+  "value.converter.schemas.enable": "false",
+
+  "topic.creation.default.replication.factor": "1",
+  "topic.creation.default.partitions": "1",
+  "topic.creation.default.cleanup.policy": "delete"
+}

--- a/client/package.json
+++ b/client/package.json
@@ -29,6 +29,7 @@
     "zustand": "^5.0.14"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
     "@tanstack/eslint-plugin-query": "^5.101.0",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/react": "^19.2.16",

--- a/docker-compose.cdc.yml
+++ b/docker-compose.cdc.yml
@@ -1,0 +1,132 @@
+# Local-only CDC backbone: Postgres logical replication -> Debezium (Kafka
+# Connect) -> Redpanda. Opt-in; merged on top of the base compose:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.override.yml \
+#     -f docker-compose.cdc.yml up -d db redpanda console connect connect-setup
+#
+# (Use the `pnpm cdc:*` scripts, which encode that command.)
+
+services:
+  # Enable logical decoding on the existing dev database. This only changes
+  # runtime flags — the cluster in the pg_data volume (and the seeded data) is
+  # untouched; Postgres just restarts. pgoutput is built in, no extra plugin.
+  db:
+    command:
+      - "postgres"
+      - "-c"
+      - "wal_level=logical"
+      - "-c"
+      - "max_wal_senders=10"
+      - "-c"
+      - "max_replication_slots=10"
+
+  redpanda:
+    image: redpandadata/redpanda:v24.2.7
+    command:
+      - redpanda
+      - start
+      - --mode=dev-container
+      - --overprovisioned
+      - --smp=1
+      - --memory=1G
+      - --reserve-memory=0M
+      - --node-id=0
+      - --check=false
+      # Two listeners: in-network clients use redpanda:9092, the host uses
+      # localhost:19092. A single advertised address can't serve both.
+      - --kafka-addr=internal://0.0.0.0:9092,external://0.0.0.0:19092
+      - --advertise-kafka-addr=internal://redpanda:9092,external://localhost:19092
+    ports:
+      - "19092:19092" # Kafka API from the host
+      - "9644:9644" # admin/metrics API
+    networks: [appnet]
+    healthcheck:
+      test: ["CMD-SHELL", "rpk cluster health | grep -q 'Healthy:.*true'"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    volumes:
+      - redpanda_data:/var/lib/redpanda/data
+
+  console:
+    image: redpandadata/console:v2.7.2
+    depends_on:
+      redpanda:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+    environment:
+      KAFKA_BROKERS: "redpanda:9092"
+      CONNECT_ENABLED: "true"
+      CONNECT_CLUSTERS_NAME: "owl-connect"
+      CONNECT_CLUSTERS_URL: "http://connect:8083"
+    networks: [appnet]
+
+  connect:
+    image: quay.io/debezium/connect:2.7.3.Final
+    depends_on:
+      redpanda:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+    ports:
+      - "8083:8083" # Connect REST API
+    environment:
+      # The Debezium image maps these well-known vars WITHOUT a CONNECT_ prefix.
+      BOOTSTRAP_SERVERS: "redpanda:9092"
+      GROUP_ID: "owl-connect"
+      CONFIG_STORAGE_TOPIC: "owl_connect_configs"
+      OFFSET_STORAGE_TOPIC: "owl_connect_offsets"
+      STATUS_STORAGE_TOPIC: "owl_connect_status"
+      # Single broker => internal topics must be RF 1.
+      CONFIG_STORAGE_REPLICATION_FACTOR: "1"
+      OFFSET_STORAGE_REPLICATION_FACTOR: "1"
+      STATUS_STORAGE_REPLICATION_FACTOR: "1"
+      # Readable JSON payloads, no Schema Registry.
+      KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
+      VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
+      # Everything else needs the CONNECT_ prefix the entrypoint translates.
+      CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE: "false"
+      CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: "false"
+      CONNECT_TOPIC_CREATION_ENABLE: "true"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8083/ >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 18
+    networks: [appnet]
+
+  # One-shot: waits for Connect, injects POSTGRES_* into the connector template,
+  # and registers it. Exits 0 when done.
+  connect-setup:
+    image: curlimages/curl:8.10.1
+    depends_on:
+      connect:
+        condition: service_healthy
+    env_file:
+      - .env.local # provides POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB
+    volumes:
+      - ./cdc/connectors:/connectors:ro
+    entrypoint: ["sh", "-c"]
+    # The template uses __TOKEN__ placeholders (not ${...}) to avoid both Compose
+    # and shell interpolation. $$ makes Compose pass a literal $ so the inner
+    # shell expands $POSTGRES_* from env_file at runtime.
+    command:
+      - |
+        set -e
+        echo "waiting for Connect REST..."
+        until curl -sf http://connect:8083/connectors >/dev/null; do sleep 2; done
+        sed -e "s|__POSTGRES_USER__|$$POSTGRES_USER|g" \
+            -e "s|__POSTGRES_PASSWORD__|$$POSTGRES_PASSWORD|g" \
+            -e "s|__POSTGRES_DB__|$$POSTGRES_DB|g" \
+            /connectors/owl-postgres.template.json > /tmp/connector.json
+        echo "registering connector (idempotent PUT)..."
+        curl -sf -X PUT -H "Content-Type: application/json" \
+          --data @/tmp/connector.json \
+          http://connect:8083/connectors/owl-postgres/config
+        echo "\nconnector registered."
+    networks: [appnet]
+    restart: "no"
+
+volumes:
+  redpanda_data:

--- a/docs/cdc.md
+++ b/docs/cdc.md
@@ -1,0 +1,97 @@
+# CDC backbone
+
+Captures row changes from Postgres and streams them onto a Kafka log, so derived
+views (like counts, timelines, trending) can be built off the event stream instead
+of querying the database on the read path.
+
+```
+Postgres (wal_level=logical) --pgoutput--> Debezium (Kafka Connect) --> Redpanda topics
+                                                                          ^
+                                                          Redpanda Console (UI :8080)
+```
+
+This is **local, opt-in infrastructure** (a separate compose file) and has no
+consumers yet — this layer only proves change events flow. Each captured table lands
+on its own topic: `owl.public.Post`, `owl.public.Like`, `owl.public.UserFollows`, etc.
+(`<topic.prefix>.<schema>.<table>`).
+
+## Run
+
+Requires Docker and the dev database already seeded (`pnpm --filter server seed`).
+
+```sh
+pnpm cdc:up       # start db (with logical replication) + redpanda + console + connect, and register the connector
+pnpm cdc:status   # connector + task state
+pnpm cdc:clean    # delete connector + drop replication slot/publication (run before cdc:down)
+pnpm cdc:down     # stop the stack (keeps volumes)
+```
+
+`cdc:up` recreates the `db` container with `wal_level=logical`; the seeded data
+survives (it lives in the `pg_data` volume). A one-shot `connect-setup` container
+injects `POSTGRES_*` from `.env.local` into the connector template and registers it,
+so no credentials are committed.
+
+- Redpanda Console UI: <http://localhost:8080> (Topics + Kafka Connect tabs)
+- Connect REST: <http://localhost:8083>
+- Kafka API from the host: `localhost:19092`
+
+## Verify
+
+```sh
+# 1) connector + task RUNNING
+curl -s http://localhost:8083/connectors/owl-postgres/status | jq
+
+# 2) topics exist
+docker exec owl-redpanda-1 rpk topic list
+
+# 3) produce a change and watch it land (op:"c" = create)
+docker exec owl-db-1 sh -c \
+  'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "INSERT INTO public.\"Like\" (\"userId\",\"postId\",\"createdAt\") VALUES (1, 1, now()) ON CONFLICT DO NOTHING;"'
+docker exec owl-redpanda-1 rpk topic consume owl.public.Like --offset end --num 1
+```
+
+Or watch it live in the Console UI.
+
+## Key choices & trade-offs
+
+- **Debezium via Kafka Connect** (not Debezium Server or the embedded engine): the
+  canonical, REST-managed, UI-visible topology — best for learning the real-world
+  shape. Debezium Server is lighter but single-sink and not visible in the Console;
+  the embedded engine couples CDC into the app process.
+- **`pgoutput`** decoding plugin — built into Postgres 16, no custom image.
+- **JSON converter, schemas off** — human-readable payloads and no Schema Registry to
+  operate. Trade-off: no enforced schema evolution / Avro; fine for a learning loop,
+  easy to upgrade later with a registry.
+- **`snapshot.mode=no_data`** — captures schema and streams only *new* changes, so the
+  first bring-up doesn't replay ~8M historical rows from the seeded data. To backfill
+  history instead, set `snapshot.mode=initial` in
+  `cdc/connectors/owl-postgres.template.json` and re-run `cdc:up` (expect a large,
+  slow snapshot).
+- **PascalCase tables**: `table.include.list` uses unquoted names (`public.Post`) — the
+  value is a regex matched against the case-sensitive stored identifier; SQL-style
+  double quotes would be treated as literal characters and fail to match.
+- **Redpanda vs Kafka**: Kafka-API compatible and far lighter (single binary, no
+  ZooKeeper). The one historical rough edge is AdminClient topic creation, so Connect's
+  internal topics and the connector's data topics are created explicitly with
+  replication factor 1 (single broker).
+
+## Operational gotchas
+
+- **The replication slot pins WAL.** Once Debezium creates `owl_cdc_slot`, Postgres
+  retains WAL until the slot's confirmed LSN advances. If Connect is stopped and left
+  down, WAL accumulates in `pg_data` and can fill the disk. Inspect with:
+  ```sql
+  SELECT slot_name, active,
+         pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)) AS retained
+  FROM pg_replication_slots;
+  ```
+- **Always `pnpm cdc:clean` before tearing down.** Deleting the connector does *not*
+  drop the slot/publication — they persist in the volume. `cdc:clean` deletes the
+  connector and drops `owl_cdc_slot` + `owl_cdc_pub`.
+- **`wal_level=logical`** writes somewhat more WAL and adds decoding CPU — negligible on
+  a dev box, but it's a real cost in production.
+
+## Next
+
+Build consumers off these topics: a like-counter view in Redis (Phase 2), timeline
+fan-out (Phase 3), trending via Flink (Phase 4).

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
     "start": "pnpm --stream -r run start",
     "build": "pnpm --stream -r run build",
     "lint": "pnpm --stream -r run lint",
-    "clean": "pnpm --stream -r run clean"
+    "clean": "pnpm --stream -r run clean",
+    "cdc:up": "docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.cdc.yml up -d db redpanda console connect connect-setup",
+    "cdc:down": "docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.cdc.yml down",
+    "cdc:status": "curl -s http://localhost:8083/connectors/owl-postgres/status",
+    "cdc:clean": "sh cdc/clean.sh"
   },
   "keywords": [],
   "author": "",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
         specifier: ^5.0.14
         version: 5.0.14(@types/react@19.2.16)(react@19.2.7)
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.4
+        version: 9.39.4
       '@tanstack/eslint-plugin-query':
         specifier: ^5.101.0
         version: 5.101.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)


### PR DESCRIPTION
Builds the spine of the derived-state architecture: captures committed row changes from Postgres and streams them onto a Kafka log, so later phases (like-counter, timeline fan-out, trending) can be built off the event stream instead of querying the DB on the read path. This phase only proves events flow — no consumers/derived views yet. Local, opt-in infra; the production compose is untouched.

## Topology
Postgres (wal_level=logical) → Debezium (Kafka Connect) → Redpanda topics, with a Redpanda Console UI.

## What's in here
- **docker-compose.cdc.yml** — opt-in, layered on the base compose: db command override for `wal_level=logical`, Redpanda broker (+ Console UI), Debezium Kafka Connect, and a one-shot `connect-setup` that registers the connector.
- **cdc/connectors/owl-postgres.template.json** — Debezium connector with `__TOKEN__` placeholders; `connect-setup` injects `POSTGRES_*` from `.env.local` at runtime (no secrets committed).
- **pnpm cdc:up/down/status/clean** + `cdc/clean.sh` — lifecycle scripts; `cdc:clean` drops the replication slot/publication.
- **docs/cdc.md** — run/verify/teardown.

## Key choices
- Debezium via **Kafka Connect** (canonical, REST-managed, UI-visible) over Debezium Server/embedded.
- **Redpanda** over Kafka (single binary, no ZooKeeper); internal topics + data topics created with RF 1.
- **pgoutput** decoding; **JSON converters, schemas off** (readable payloads, no Schema Registry).
- **snapshot.mode=no_data** — streams only new changes, avoiding an ~8M-event backfill of the seeded data (switch to `initial` to backfill history).

## Verified
Connector + task RUNNING; inserting a `Post` produced an `op:"c"` Debezium event on `owl.public.Post`.

## Gotcha documented
The replication slot pins WAL while it exists — `cdc:clean` must run before teardown so WAL doesn't accumulate. (Also: `fix(client)` declares `@eslint/js`, which CI's stricter install needs.)