### PR TITLE
chore(deploy): prune dangling images after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,3 +48,6 @@ jobs:
             git pull origin main
             docker compose -f docker-compose.yml pull
             docker compose -f docker-compose.yml up -d
+            # Reclaim disk from old image layers replaced by the new :latest
+            # (otherwise dangling images accumulate and fill the EBS volume).
+            docker image prune -f


### PR DESCRIPTION
Each deploy pulls a new `:latest`, leaving the previous image layers dangling. They accumulated on the EC2 box and filled the disk (the last deploy failed with `no space left on device`). Add `docker image prune -f` at the end of the deploy script so old layers are reclaimed every run.

Note: only removes *dangling* (untagged) images — running containers and the named volumes (`pg_data`) are untouched. Longer-term, also worth bumping the EBS volume size.