### PR TITLE
fix: make reply creation + parent commentsCount increment atomic

### DIFF
--- a/server/src/features/post/postController.ts
+++ b/server/src/features/post/postController.ts
@@ -250,26 +250,7 @@ export async function createPost(req: Request, res: Response) {
 
     const { text, images } = input.data;
 
-    // Check if the parent post exists
-    if (parentPostId) {
-      const parentPost = await prisma.post.findUnique({
-        where: { id: parentPostId },
-      });
-
-      if (!parentPost) {
-        res.status(404).json({ error: 'Parent post not found' });
-        return;
-      }
-
-      // Increment the comments count of the parent post
-      await prisma.post.update({
-        where: { id: parentPostId },
-        data: { commentsCount: { increment: 1 } },
-      });
-    }
-
-    // Create post
-    const post = await prisma.post.create({
+    const postArgs = {
       data: {
         text,
         images: images ?? undefined,
@@ -295,7 +276,30 @@ export async function createPost(req: Request, res: Response) {
           },
         },
       },
-    });
+    };
+
+    // Verify the parent exists (for a clean 404) before creating a reply.
+    if (parentPostId) {
+      const parentPost = await prisma.post.findUnique({
+        where: { id: parentPostId },
+      });
+      if (!parentPost) {
+        res.status(404).json({ error: 'Parent post not found' });
+        return;
+      }
+    }
+
+    // For a reply, create the post and bump the parent's commentsCount in one
+    // transaction so the count can't drift if either write fails.
+    const post = parentPostId
+      ? await prisma.$transaction(async (tx) => {
+          await tx.post.update({
+            where: { id: parentPostId },
+            data: { commentsCount: { increment: 1 } },
+          });
+          return tx.post.create(postArgs);
+        })
+      : await prisma.post.create(postArgs);
 
     res.status(201).json({ post });
   } catch (error) {

--- a/server/src/test/engagement.test.ts
+++ b/server/src/test/engagement.test.ts
@@ -51,6 +51,23 @@ describe('counter integrity', () => {
     expect((await prisma.user.findUnique({ where: { id: bId } }))?.followersCount).toBe(0);
     expect(await prisma.userFollows.count()).toBe(0);
   });
+
+  it('creating a reply increments the parent commentsCount (atomically)', async () => {
+    const authorId = await createUser('author');
+    const parent = await prisma.post.create({
+      data: { postedById: authorId, text: 'parent' },
+    });
+
+    await request(app)
+      .post(`/api/v1/posts/${parent.id}`)
+      .set('Authorization', authHeader(authorId))
+      .send({ text: 'a reply' })
+      .expect(201);
+
+    const updated = await prisma.post.findUnique({ where: { id: parent.id } });
+    expect(updated?.commentsCount).toBe(1);
+    expect(await prisma.post.count({ where: { parentPostId: parent.id } })).toBe(1);
+  });
 });
 
 describe('searchUsers follow status (batched)', () => {


### PR DESCRIPTION
`createPost` incremented the parent post's `commentsCount` in a separate statement from creating the reply (not in a transaction), so a crash/failure between the two drifted the count permanently — the same dual-write hazard fixed elsewhere in the baseline phase, but `createPost` was missed.

Verify the parent exists (for a clean 404), then run the `commentsCount` increment + the reply `create` in one `prisma.$transaction`. Adds a regression test that a reply bumps the parent's `commentsCount`.