### PR TITLE
fix(client): resolve feed endpoint in body, not a default param

### DIFF
--- a/client/src/hooks/usePosts.tsx
+++ b/client/src/hooks/usePosts.tsx
@@ -25,9 +25,13 @@ type PostsResponse = {
   nextCursor: number | null;
 };
 
-export function usePosts(endpoint = location.pathname) {
+export function usePosts(endpointArg?: string) {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const location = useLocation();
+  // Resolve in the body, not a default param: a default `= location.pathname`
+  // references the `location` const below, which is a TDZ hazard the bundler
+  // resolved to undefined (→ requests to "postsundefined").
+  const endpoint = endpointArg ?? location.pathname;
 
   const { data, isPending, isError, hasNextPage, fetchNextPage, isFetching } =
     useInfiniteQuery({


### PR DESCRIPTION
usePosts had `endpoint = location.pathname` as a default parameter, but `location` is the `const` declared on the next line (useLocation()) — a temporal-dead-zone reference. The toolchain upgrade (Vite 8/esbuild, which doesn't guard TDZ) resolved it to undefined, so PostList rendered without an endpoint prop requested "posts" + undefined = "/api/v1/postsundefined" (404). Resolve endpoint inside the body from the real router location instead.