### PR TITLE
feat: make the demo seed runnable in production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,29 @@ services:
     working_dir: /app
     command: ["npx", "prisma", "migrate", "deploy"]
 
+  # One-off curated demo seed. Behind the "seed" profile so it never runs on a
+  # normal `up`; invoke explicitly:
+  #   docker compose --profile seed run --rm seed-demo
+  # Shares the uploads volume + UPLOAD_DIR with the server so seeded image files
+  # land where the server serves them. Safe + idempotent (see prisma/seed/demo.ts).
+  seed-demo:
+    image: ghcr.io/ulixert/owl-server:latest
+    profiles: ["seed"]
+    env_file:
+      - ./server/.prod.env
+    environment:
+      UPLOAD_DIR: /app/uploads
+      DEMO_SEED_CONFIRM: "1"
+    depends_on:
+      db:
+        condition: service_healthy
+    networks: [appnet]
+    restart: "no"
+    working_dir: /app
+    volumes:
+      - uploads:/app/uploads
+    command: ["node", "dist/seed-demo.mjs"]
+
   caddy:
     image: ghcr.io/ulixert/owl-client:latest
     ports:

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -66,7 +66,23 @@ handwritten posts with reply threads and likes — so prod doesn't look empty.
   all real data untouched.
 - Any demo handle logs in with `DEMO_PASSWORD` (default `owldemo123`).
 
-To seed prod, run it with the prod `DATABASE_URL` **and** the prod `UPLOAD_DIR` (i.e.
-inside the server container / against its volume) so the media files land where the
-server serves them. Note: re-running orphans the previous run's upload files (new UUIDs
-each time) — harmless, but clear the volume if you care.
+### Running it locally
+
+```
+DEMO_SEED_CONFIRM=1 pnpm --filter server seed:demo   # tsx, against .env / dev DB
+```
+
+### Running it in prod
+
+The seed compiles to `dist/seed-demo.mjs` (a second `tsdown` entry) so it runs with
+plain `node` in the prod image — no `tsx`, and the bundle pulls in `src/storage`. A
+one-off `seed-demo` compose service runs it **inside the server container**, sharing the
+`uploads` volume and `UPLOAD_DIR=/app/uploads` so seeded media files land where the
+server serves them. It's behind the `seed` profile, so it never runs on a normal `up`:
+
+```
+docker compose --profile seed run --rm seed-demo
+```
+
+Note: re-running orphans the previous run's upload files (new UUIDs each time) —
+harmless, but clear the `uploads` volume if you care.

--- a/server/prisma/seed/demo.ts
+++ b/server/prisma/seed/demo.ts
@@ -14,7 +14,6 @@ import argon2 from '@node-rs/argon2';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { PrismaClient } from '../../generated/prisma/client.js';
 import { storage } from '../../src/storage/index.js';
@@ -26,7 +25,11 @@ const NOW = Date.now();
 // Override with DEMO_PASSWORD; defaults to something obvious and harmless.
 const DEMO_PASSWORD = process.env.DEMO_PASSWORD ?? 'owldemo123';
 
-const ASSET_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), 'assets');
+// Resolved against the working directory rather than this file's location, so it
+// works both run from source via tsx (cwd = server/) and as the bundled dist
+// build inside the container (cwd = /app); both have prisma/seed/assets. Override
+// with DEMO_ASSET_DIR if needed.
+const ASSET_DIR = process.env.DEMO_ASSET_DIR ?? path.resolve('prisma/seed/assets');
 
 // Push a committed SVG asset through the real storage backend (disk now, S3
 // later) and return the public URL — the same path a user upload takes, so the

--- a/server/tsdown.config.ts
+++ b/server/tsdown.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['src/server.ts'],
+  // The demo seed is a second entry so it compiles to dist/seed-demo.mjs and can
+  // run with plain node in prod (the image has no tsx). Bundling pulls in src/
+  // (the storage backend) which isn't otherwise copied into the runtime image.
+  entry: {
+    server: 'src/server.ts',
+    'seed-demo': 'prisma/seed/demo.ts',
+  },
   format: ['esm'],
   platform: 'node',
   target: 'es2022',


### PR DESCRIPTION
## Why
The curated demo seed couldn't run against prod: the image ships prod-only deps (no `tsx`), doesn't include `src/` (the seed imports the storage backend), and uploaded files needed to land in the server's `uploads` volume or they'd 404.

## What
- Compile the seed as a second `tsdown` entry → `dist/seed-demo.mjs`, runnable with plain `node`. Bundling pulls in `src/storage`; the Prisma client resolves via `../generated/prisma` exactly like `server.mjs`.
- Resolve seed assets relative to cwd so the bundled build finds `prisma/seed/assets` in the container.
- Add a one-off `seed-demo` compose service (behind a `seed` profile) that runs inside the server container, sharing the `uploads` volume + `UPLOAD_DIR`.

## How to seed prod (after this deploys)
`docker compose --profile seed run --rm seed-demo`

## Testing
- Built locally; ran the compiled `node dist/seed-demo.mjs` with env-var config and a custom UPLOAD_DIR against a dev DB: 8 users / 19 posts, media written, idempotent. Server typecheck + lint clean.