### PR TITLE
feat: timeline fan-out for the Following feed (hybrid CDC view)

### DIFF
--- a/docs/feed.md
+++ b/docs/feed.md
@@ -1,0 +1,54 @@
+# Timeline fan-out (Following feed)
+
+The "Following" timeline moved from a **pull model** (fan-in query at read time) to a
+**fan-out-on-write** derived view: a per-user feed precomputed in Redis from the CDC
+stream, with a **read-time merge for celebrities** (the hybrid model).
+
+```
+POST /posts ──> INSERT "Post" row   (the only write — the source of truth)
+                      │
+                Debezium CDC
+                      │
+              owl.public.Post  (Redpanda)
+                      │
+            timeline-fanout consumer ──> for each follower F (non-celebrity author):
+                                              ZADD feed:{F} score=postId
+                      │
+   GET /posts/following ──> ZREVRANGEBYSCORE feed:{me}  ⊕  recent posts from
+                            followed celebrities (DB)  ──> hydrate ──> response
+```
+
+- **Truth**: `Post` rows in Postgres. The write path only inserts/updates a Post.
+- **View**: `feed:{userId}` — a Redis ZSET, member = `postId`, score = `postId`. Post ids are monotonic with creation time, so scoring by id gives chronological order and matches the keyset-by-id pagination used everywhere else.
+- **Rebuildable**: `feed:reconcile` rebuilds feeds from the truth.
+
+## Run (after `pnpm cdc:up`, which includes Redis)
+
+```sh
+pnpm --filter server feed:reconcile          # warm/repair feeds from Postgres (all users)
+pnpm --filter server feed:reconcile -- 1 2 3 # ...or just these user ids
+pnpm --filter server consume:feed            # long-running: apply live Post CDC events
+```
+
+The API (`pnpm --filter server dev`) reads from the feed automatically, falling back to the pull query when Redis is cold or down.
+
+## Design notes & trade-offs
+
+- **Fan-out-on-write, single writer.** The consumer is the only writer of `feed:*`; the API only reads. On a new post by author A, it pushes the post id into every follower's feed (plus A's own, so authors see their posts). Reads become a cheap range scan of one per-user list instead of a fan-in `WHERE postedById IN (...)`.
+- **Hybrid: celebrities are NOT fanned out.** An author with `>= CELEBRITY_FOLLOWER_THRESHOLD` (default 10000) followers would cause huge write amplification (one post → millions of ZADDs). Those authors are skipped on write and **merged in at read time**: the read path pulls the followed celebrities' recent posts straight from Postgres (rides the `Post(postedById, id)` index) and merges them with the Redis slice. This is the canonical "when NOT to fan out" point.
+- **Bounded feeds.** Each feed is trimmed to the newest `FEED_MAX` (default 800) ids (`ZREMRANGEBYRANK`). Deeper pages fall back to the DB pull query — the feed is a hot cache of recent history, not the whole timeline.
+- **Eventual consistency.** A new post appears once the consumer processes its CDC event (typically sub-second), not synchronously. Same deliberate trade-off as the like-counter view: decoupling + a simpler write path in exchange for read-your-writes.
+- **Soft-delete handling.** `deletePost` sets `isDeleted=true` (an `update`), so Debezium emits an `op=u` carrying `postedById` — the consumer fans out a `ZREM`. No `REPLICA IDENTITY FULL` needed (unlike the `Like` view). As a safety net, the read path re-checks `isDeleted` and id-membership when hydrating, so any stale id left in a ZSET is dropped on read.
+- **Graceful degradation / cold start.** `getFollowingFeedIds` returns `null` — and the endpoint serves the original pull query — when Redis isn't `ready`, the feed key doesn't exist yet (new/unwarmed user), or we've paged past what the feed holds. The endpoint stays correct with the streaming stack off entirely.
+- **Reconcile = rebuild from source.** `feed:reconcile` recomputes each feed from the newest `FEED_MAX` posts of a user's non-celebrity followees (+ their own) and rewrites the ZSET. Warms cold feeds and repairs the consumer's at-least-once edges. On the 100k-user load-test dataset a full backfill is expensive; pass explicit ids to warm a subset (cold feeds fall back to the DB anyway).
+
+## Verified
+
+End-to-end against the live CDC stack: a post by a normal author (`ada`, 5 followers) appeared in every follower's `feed:*` and in the author's own feed, and not in a non-follower's; soft-deleting it removed it from those feeds. A celebrity's post (user 1, 67.5k followers) was **not** fanned out, and is surfaced only via the read-time merge. Unit tests cover `postEventEffect` (CDC mapping) and `mergeFeedPages`; integration tests cover the Redis-hit, cold-fallback, and celebrity-merge read paths.
+
+## Out of scope / next
+
+- **Prod**: consumers stay local (run via `pnpm`), matching the like-counter and the "CDC not in prod for now" decision. No new compose/CI service.
+- **For-You** (`getRecommendedPosts`) is unchanged — it's a ranking problem, handled on its own branch; it can later reuse this feed for its "following" slice and the trending view for its "popular" slice.
+- Replies are fanned out like top-level posts (preserving current behavior); filtering them out of the home feed is a possible product refinement.
+- Next: trending via Flink (Phase 4).

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,8 @@
     "seed:demo": "tsx --env-file=.env prisma/seed/demo.ts",
     "like:reconcile": "tsx --env-file=.env src/scripts/reconcileLikeCounts.ts",
     "consume:likes": "tsx --env-file=.env src/consumers/likeCounter.ts",
+    "feed:reconcile": "tsx --env-file=.env src/scripts/reconcileFeeds.ts",
+    "consume:feed": "tsx --env-file=.env src/consumers/timelineFanout.ts",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/server/src/consumers/timelineFanout.ts
+++ b/server/src/consumers/timelineFanout.ts
@@ -1,0 +1,102 @@
+// CDC consumer: maintains the per-user "Following" feeds (feed:{userId} ZSETs)
+// by fanning out Post change events from owl.public.Post.
+//
+//   pnpm --filter server consume:feed
+//
+// Fan-out-on-write for the long tail; celebrities (>= CELEBRITY_FOLLOWER_THRESHOLD
+// followers) are skipped here and merged in at read time instead, to avoid write
+// amplification. Offsets are committed, so a restart resumes; `feed:reconcile`
+// rebuilds feeds from Postgres if they drift.
+
+import { Kafka, logLevel } from 'kafkajs';
+
+import { prisma } from '../db/index.js';
+import {
+  CELEBRITY_FOLLOWER_THRESHOLD,
+  FEED_MAX,
+  feedKey,
+  postEventEffect,
+} from '../features/post/feed.js';
+import { redis } from '../redis.js';
+
+const TOPIC = 'owl.public.Post';
+const brokers = (process.env.KAFKA_BROKERS ?? 'localhost:19092').split(',');
+
+const kafka = new Kafka({
+  clientId: 'owl-timeline-fanout',
+  brokers,
+  logLevel: logLevel.WARN,
+});
+const consumer = kafka.consumer({ groupId: 'owl-timeline-fanout' });
+
+// The audience for a post: the author's followers plus the author (so they see
+// their own posts), matching the pull model's `followedIds.push(currentUserId)`.
+async function audienceOf(authorId: number): Promise<number[]> {
+  const followers = await prisma.userFollows.findMany({
+    where: { followingId: authorId },
+    select: { followerId: true },
+  });
+  return [...followers.map((f) => f.followerId), authorId];
+}
+
+async function applyAdd(postId: number, authorId: number): Promise<void> {
+  // Skip celebrities — too many followers to fan out; read-time merge covers them.
+  const author = await prisma.user.findUnique({
+    where: { id: authorId },
+    select: { followersCount: true },
+  });
+  if (!author || author.followersCount >= CELEBRITY_FOLLOWER_THRESHOLD) return;
+
+  const audience = await audienceOf(authorId);
+  const pipeline = redis.pipeline();
+  for (const userId of audience) {
+    pipeline.zadd(feedKey(userId), postId, String(postId));
+    pipeline.zremrangebyrank(feedKey(userId), 0, -(FEED_MAX + 1)); // cap newest N
+  }
+  await pipeline.exec();
+}
+
+async function applyRemove(postId: number, authorId: number): Promise<void> {
+  const audience = await audienceOf(authorId);
+  const pipeline = redis.pipeline();
+  for (const userId of audience) {
+    pipeline.zrem(feedKey(userId), String(postId));
+  }
+  await pipeline.exec();
+}
+
+async function main(): Promise<void> {
+  await consumer.connect();
+  await consumer.subscribe({ topic: TOPIC, fromBeginning: true });
+  console.log(`[timeline-fanout] consuming ${TOPIC} from ${brokers.join(',')}`);
+
+  await consumer.run({
+    eachMessage: async ({ message }) => {
+      if (!message.value) return; // tombstone
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(message.value.toString());
+      } catch {
+        return;
+      }
+      const effect = postEventEffect(parsed);
+      if (!effect) return;
+      if (effect.op === 'add') await applyAdd(effect.postId, effect.authorId);
+      else await applyRemove(effect.postId, effect.authorId);
+    },
+  });
+}
+
+async function shutdown(): Promise<void> {
+  console.log('\n[timeline-fanout] shutting down...');
+  await consumer.disconnect().catch(() => undefined);
+  redis.disconnect();
+  process.exit(0);
+}
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+main().catch((err: unknown) => {
+  console.error('[timeline-fanout] fatal:', err);
+  process.exit(1);
+});

--- a/server/src/features/post/currentUserPostController.ts
+++ b/server/src/features/post/currentUserPostController.ts
@@ -2,7 +2,55 @@ import { Request, Response } from 'express';
 
 import { prisma } from '../../db';
 import { postQuerySchema } from '../../types/validation/schemas.js';
+import { getFollowingFeedIds } from './feed.js';
 import { withLikeCounts } from './likeCounts.js';
+
+// Shared include shape for feed posts: author summary, parent author (for reply
+// context), and the viewer's own like row (to derive isLiked).
+function feedInclude(viewerId: number | undefined) {
+  return {
+    postedBy: { select: { id: true, username: true, name: true, profilePic: true } },
+    parentPost: { select: { postedBy: { select: { username: true } } } },
+    likes: viewerId ? { where: { userId: viewerId } } : undefined,
+  };
+}
+
+function withIsLiked<T extends { likes?: unknown[] }>(post: T) {
+  const { likes, ...rest } = post;
+  return { ...rest, isLiked: likes ? likes.length > 0 : false };
+}
+
+// The original pull model: fan-in query over followed authors. Used directly
+// when the Redis feed is cold/down, and to hydrate the merged id page below.
+async function getFollowingPostsFromDb(
+  viewerId: number,
+  cursor: number,
+  limit: number,
+) {
+  const followedUsers = await prisma.userFollows.findMany({
+    where: { followerId: viewerId },
+    select: { followingId: true },
+  });
+  const followedIds = followedUsers.map((f) => f.followingId);
+  followedIds.push(viewerId); // include the viewer's own posts
+
+  const posts = await prisma.post.findMany({
+    where: {
+      postedById: { in: followedIds },
+      isDeleted: false,
+      ...(cursor ? { id: { lt: cursor } } : {}),
+    },
+    orderBy: { id: 'desc' },
+    take: limit,
+    include: feedInclude(viewerId),
+  });
+
+  const nextCursor = posts.length === limit ? posts[posts.length - 1].id : null;
+  return {
+    posts: await withLikeCounts(posts.map(withIsLiked)),
+    nextCursor,
+  };
+}
 
 export async function getFollowingPosts(req: Request, res: Response) {
   try {
@@ -13,68 +61,31 @@ export async function getFollowingPosts(req: Request, res: Response) {
     }
 
     const currentUserId = req.user!.id;
-
     const { cursor, limit } = input.data;
 
-    // Get followed users (and include the current user)
-    const followedUsers = await prisma.userFollows.findMany({
-      where: { followerId: currentUserId },
-      select: { followingId: true },
+    // Hybrid read: the precomputed Redis feed merged with followed celebrities.
+    // Returns null when we should serve straight from Postgres (Redis cold/down,
+    // or paged past what the feed holds).
+    const ids = await getFollowingFeedIds(currentUserId, cursor, limit);
+    if (ids === null) {
+      res.status(200).json(await getFollowingPostsFromDb(currentUserId, cursor, limit));
+      return;
+    }
+
+    // Hydrate the id page. The isDeleted filter + id-membership drop any stale
+    // ids left in the feed, so missed deletes are harmless.
+    const rows = await prisma.post.findMany({
+      where: { id: { in: ids }, isDeleted: false },
+      include: feedInclude(currentUserId),
     });
+    rows.sort((a, b) => b.id - a.id);
 
-    const followedIds = followedUsers.map((follow) => follow.followingId);
-    followedIds.push(currentUserId);
-
-    // Fetch posts with pagination
-    const posts = await prisma.post.findMany({
-      where: {
-        postedById: { in: followedIds },
-        isDeleted: false,
-        ...(cursor ? { id: { lt: cursor } } : {}),
-      },
-      orderBy: { id: 'desc' },
-      take: limit,
-      include: {
-        postedBy: {
-          select: {
-            id: true,
-            username: true,
-            name: true,
-            profilePic: true,
-          },
-        },
-        parentPost: {
-          select: {
-            postedBy: {
-              select: {
-                username: true,
-              },
-            },
-          },
-        },
-        likes: req.user
-          ? {
-              where: {
-                userId: req.user.id,
-              },
-            }
-          : undefined,
-      },
-    });
-
-    const postsWithIsLiked = posts.map((post) => {
-      const { likes, ...rest } = post;
-      return {
-        ...rest,
-        isLiked: likes ? likes.length > 0 : false,
-      };
-    });
-
-    const nextCursor =
-      posts.length === limit ? posts[posts.length - 1].id : null;
+    // Cursor continues from the last *candidate* id (even if some were filtered),
+    // so pagination doesn't skip posts.
+    const nextCursor = ids.length === limit ? ids[ids.length - 1] : null;
 
     res.status(200).json({
-      posts: await withLikeCounts(postsWithIsLiked),
+      posts: await withLikeCounts(rows.map(withIsLiked)),
       nextCursor,
     });
   } catch (error) {

--- a/server/src/features/post/feed.ts
+++ b/server/src/features/post/feed.ts
@@ -1,0 +1,162 @@
+// The timeline fan-out view: a per-user "Following" feed precomputed in Redis,
+// maintained from the CDC stream (owl.public.Post) by the timelineFanout consumer.
+//
+//   feed:{userId}  → ZSET, member = postId, score = postId
+//
+// Post ids are monotonic with creation time, so scoring by id gives chronological
+// order and matches the keyset-by-id pagination used everywhere else (the cursor
+// is a post id). The feed is a CACHE, not the source of truth: Postgres stays
+// authoritative and the read path falls back to a plain query when Redis is cold
+// or down (see getFollowingPosts).
+
+import { prisma } from '../../db/index.js';
+import { redis } from '../../redis.js';
+
+/** Newest N posts kept per feed; deeper pages fall back to Postgres. */
+export const FEED_MAX = Number(process.env.FEED_MAX ?? 800);
+
+/** Authors with at least this many followers are NOT fanned out (write
+ *  amplification); their posts are merged in at read time instead. */
+export const CELEBRITY_FOLLOWER_THRESHOLD = Number(
+  process.env.CELEBRITY_FOLLOWER_THRESHOLD ?? 10_000,
+);
+
+export const feedKey = (userId: number) => `feed:${userId}`;
+
+export type FeedEffect = {
+  op: 'add' | 'remove';
+  postId: number;
+  authorId: number;
+};
+
+type DebeziumPostRow = {
+  id?: number;
+  postedById?: number;
+  isDeleted?: boolean;
+} | null;
+
+type DebeziumPostValue = {
+  op?: string;
+  before?: DebeziumPostRow;
+  after?: DebeziumPostRow;
+};
+
+/**
+ * Pure mapping from a Debezium `Post` change event (JSON, schemas off) to its
+ * effect on the per-user feeds:
+ *   - create / snapshot-read of a live post  => add
+ *   - update that flips isDeleted to true     => remove (soft delete)
+ *   - hard delete                             => remove (needs before.postedById)
+ * Returns null for events that don't change feed membership.
+ */
+export function postEventEffect(value: unknown): FeedEffect | null {
+  const event = value as DebeziumPostValue | null;
+  const row = (which: DebeziumPostRow | undefined): FeedEffect | null =>
+    typeof which?.id === 'number' && typeof which?.postedById === 'number'
+      ? { op: 'add', postId: which.id, authorId: which.postedById }
+      : null;
+
+  switch (event?.op) {
+    case 'c':
+    case 'r': {
+      if (event.after?.isDeleted) return null;
+      return row(event.after);
+    }
+    case 'u': {
+      // Only soft-deletes change membership; ordinary edits don't.
+      if (!event.after?.isDeleted) return null;
+      const effect = row(event.after);
+      return effect && { ...effect, op: 'remove' };
+    }
+    case 'd': {
+      // Hard delete: the before image carries postedById only with REPLICA
+      // IDENTITY FULL; without it we return null and rely on read-time hydration
+      // (which filters deleted/missing posts) as the safety net.
+      const effect = row(event.before);
+      return effect && { ...effect, op: 'remove' };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Merge the fanned-out feed ids (Redis) with celebrity post ids (DB), newest
+ * first, de-duplicated, capped to `limit`. Pure — both inputs are id lists.
+ */
+export function mergeFeedPages(
+  redisIds: number[],
+  celebIds: number[],
+  limit: number,
+): number[] {
+  const unique = [...new Set([...redisIds, ...celebIds])];
+  unique.sort((a, b) => b - a);
+  return unique.slice(0, limit);
+}
+
+/** The celebrity authors a user follows (resolved from the DB, always current). */
+export async function getFollowedCelebrities(userId: number): Promise<number[]> {
+  const rows = await prisma.userFollows.findMany({
+    where: {
+      followerId: userId,
+      following: { followersCount: { gte: CELEBRITY_FOLLOWER_THRESHOLD } },
+    },
+    select: { followingId: true },
+  });
+  return rows.map((r) => r.followingId);
+}
+
+/**
+ * Resolve the page of post ids for a user's Following feed, hybrid-style:
+ * the Redis fan-out slice merged with recent posts from followed celebrities.
+ * Returns null to signal the caller should fall back to the plain DB query —
+ * when Redis is down, the feed isn't built yet, or we've paged past what Redis
+ * holds (deeper history lives only in Postgres).
+ */
+export async function getFollowingFeedIds(
+  userId: number,
+  cursor: number,
+  limit: number,
+): Promise<number[] | null> {
+  if (redis.status !== 'ready') return null;
+
+  try {
+    if (!(await redis.exists(feedKey(userId)))) return null;
+
+    const max = cursor > 0 ? `(${cursor}` : '+inf';
+    const redisIds = (
+      await redis.zrevrangebyscore(
+        feedKey(userId),
+        max,
+        '-inf',
+        'LIMIT',
+        0,
+        limit,
+      )
+    ).map(Number);
+
+    // No fanned-out posts at/under the cursor: cold or past the cap — fall back.
+    if (redisIds.length === 0) return null;
+
+    const celebrities = await getFollowedCelebrities(userId);
+    let celebIds: number[] = [];
+    if (celebrities.length > 0) {
+      const rows = await prisma.post.findMany({
+        where: {
+          postedById: { in: celebrities },
+          isDeleted: false,
+          ...(cursor > 0 ? { id: { lt: cursor } } : {}),
+        },
+        orderBy: { id: 'desc' },
+        take: limit,
+        select: { id: true },
+      });
+      celebIds = rows.map((r) => r.id);
+    }
+
+    return mergeFeedPages(redisIds, celebIds, limit);
+  } catch (err) {
+    console.error('[feed] redis read failed, falling back to db:', (err as Error).message);
+    return null;
+  }
+}

--- a/server/src/scripts/reconcileFeeds.ts
+++ b/server/src/scripts/reconcileFeeds.ts
@@ -1,0 +1,87 @@
+// Warms the per-user "Following" feeds (feed:{userId} ZSETs) from Postgres.
+// Feeds are a cache — cold feeds already fall back to the DB pull query — so this
+// is for warming and for repairing drift from the fan-out consumer, not for
+// correctness.
+//
+//   pnpm --filter server feed:reconcile            # all users
+//   pnpm --filter server feed:reconcile -- 1 2 3   # only these user ids
+//
+// For each user it loads the newest FEED_MAX posts from the non-celebrity authors
+// they follow (plus their own) and ZADDs them. Celebrities are intentionally
+// excluded — they're merged at read time. On the 100k-user load-test dataset a
+// full backfill is expensive; pass an explicit id list to warm a subset.
+
+import { Pool } from 'pg';
+
+import {
+  CELEBRITY_FOLLOWER_THRESHOLD,
+  FEED_MAX,
+  feedKey,
+} from '../features/post/feed.js';
+import { redis } from '../redis.js';
+
+async function main(): Promise<void> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) throw new Error('DATABASE_URL is not set.');
+  const pool = new Pool({ connectionString, max: 2 });
+
+  const explicitIds = process.argv
+    .slice(2)
+    .map(Number)
+    .filter((n) => Number.isInteger(n));
+
+  const started = Date.now();
+  try {
+    const { rows: users } = explicitIds.length
+      ? await pool.query<{ id: number }>(
+          'SELECT id FROM "User" WHERE id = ANY($1)',
+          [explicitIds],
+        )
+      : await pool.query<{ id: number }>('SELECT id FROM "User" ORDER BY id');
+
+    console.log(`Reconciling feeds for ${users.length} users...`);
+    let done = 0;
+    for (const { id: userId } of users) {
+      // Newest FEED_MAX posts from non-celebrity followees + the user's own.
+      const { rows: posts } = await pool.query<{ id: number }>(
+        `SELECT p.id
+           FROM "Post" p
+          WHERE p."isDeleted" = false
+            AND p."postedById" IN (
+              SELECT $1::int
+              UNION
+              SELECT f."followingId"
+                FROM "UserFollows" f
+                JOIN "User" u ON u.id = f."followingId"
+               WHERE f."followerId" = $1::int
+                 AND u."followersCount" < $2::int
+            )
+          ORDER BY p.id DESC
+          LIMIT $3::int`,
+        [userId, CELEBRITY_FOLLOWER_THRESHOLD, FEED_MAX],
+      );
+
+      const key = feedKey(userId);
+      const pipeline = redis.pipeline();
+      pipeline.del(key); // rebuild from scratch (idempotent)
+      for (const { id } of posts) pipeline.zadd(key, id, String(id));
+      await pipeline.exec();
+
+      done++;
+      if (done % 500 === 0 || done === users.length) {
+        process.stdout.write(`  ${done}/${users.length}\r`);
+      }
+    }
+
+    const secs = ((Date.now() - started) / 1000).toFixed(1);
+    console.log(`\n✓ reconciled ${done} feeds in ${secs}s`);
+  } finally {
+    await pool.end();
+    redis.disconnect();
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error('\nReconcile failed:', err);
+  process.exit(1);
+});

--- a/server/src/test/feed.test.ts
+++ b/server/src/test/feed.test.ts
@@ -1,0 +1,158 @@
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { app } from '../app.js';
+import { prisma } from '../db/index.js';
+import {
+  CELEBRITY_FOLLOWER_THRESHOLD,
+  feedKey,
+  mergeFeedPages,
+  postEventEffect,
+} from '../features/post/feed.js';
+import { redis } from '../redis.js';
+import { authHeader, createUser, resetDb } from './helpers.js';
+
+describe('postEventEffect (CDC mapping)', () => {
+  const post = { id: 7, postedById: 3, isDeleted: false };
+
+  it('maps create and snapshot-read of a live post to add', () => {
+    expect(postEventEffect({ op: 'c', after: post })).toEqual({
+      op: 'add',
+      postId: 7,
+      authorId: 3,
+    });
+    expect(postEventEffect({ op: 'r', after: post })).toEqual({
+      op: 'add',
+      postId: 7,
+      authorId: 3,
+    });
+  });
+
+  it('maps a soft delete (update flipping isDeleted) to remove', () => {
+    expect(
+      postEventEffect({ op: 'u', after: { ...post, isDeleted: true } }),
+    ).toEqual({ op: 'remove', postId: 7, authorId: 3 });
+  });
+
+  it('maps a hard delete to remove using the before image', () => {
+    expect(postEventEffect({ op: 'd', before: post })).toEqual({
+      op: 'remove',
+      postId: 7,
+      authorId: 3,
+    });
+  });
+
+  it('ignores ordinary edits, creates of deleted posts, and malformed events', () => {
+    expect(postEventEffect({ op: 'u', after: post })).toBeNull();
+    expect(postEventEffect({ op: 'c', after: { ...post, isDeleted: true } })).toBeNull();
+    expect(postEventEffect(null)).toBeNull();
+    expect(postEventEffect({})).toBeNull();
+    expect(postEventEffect({ op: 'c', after: { id: 7 } })).toBeNull();
+  });
+});
+
+describe('mergeFeedPages', () => {
+  it('merges newest-first, de-dupes, and caps to limit', () => {
+    expect(mergeFeedPages([9, 6, 3], [8, 6, 2], 4)).toEqual([9, 8, 6, 3]);
+  });
+
+  it('handles an empty celebrity slice', () => {
+    expect(mergeFeedPages([5, 4], [], 10)).toEqual([5, 4]);
+  });
+});
+
+describe('Following feed read path (Redis-backed, hybrid)', () => {
+  let viewer: number;
+  let author: number;
+  let normal: number;
+  let celeb: number;
+
+  beforeAll(async () => {
+    await resetDb();
+    viewer = await createUser('viewer');
+    author = await createUser('author');
+    normal = await createUser('normal');
+    // A celebrity the viewer follows: above the fan-out threshold.
+    const c = await prisma.user.create({
+      data: {
+        username: 'celeb',
+        email: 'celeb@example.com',
+        name: 'celeb',
+        password: 'x',
+        followersCount: CELEBRITY_FOLLOWER_THRESHOLD + 1,
+      },
+    });
+    celeb = c.id;
+
+    await prisma.userFollows.createMany({
+      data: [
+        { followerId: viewer, followingId: author },
+        { followerId: viewer, followingId: normal },
+        { followerId: viewer, followingId: celeb },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await redis.del(feedKey(viewer));
+  });
+
+  it('serves the precomputed feed from Redis when warm', async () => {
+    const post = await prisma.post.create({
+      data: { postedById: author, text: 'from redis' },
+    });
+    await redis.zadd(feedKey(viewer), post.id, String(post.id));
+
+    const res = await request(app)
+      .get('/api/v1/posts/following')
+      .set('Authorization', authHeader(viewer));
+    const body = res.body as { posts: { id: number }[] };
+
+    expect(res.status).toBe(200);
+    expect(body.posts.map((p) => p.id)).toContain(post.id);
+
+    await redis.del(feedKey(viewer));
+    await prisma.post.delete({ where: { id: post.id } });
+  });
+
+  it('falls back to the DB pull model when the feed key is missing', async () => {
+    const post = await prisma.post.create({
+      data: { postedById: author, text: 'from db' },
+    });
+
+    const res = await request(app)
+      .get('/api/v1/posts/following')
+      .set('Authorization', authHeader(viewer));
+    const body = res.body as { posts: { id: number }[] };
+
+    expect(res.status).toBe(200);
+    expect(body.posts.map((p) => p.id)).toContain(post.id);
+
+    await prisma.post.delete({ where: { id: post.id } });
+  });
+
+  it('merges followed celebrities at read time (not from the feed ZSET)', async () => {
+    // A normal post is fanned out into the ZSET; the celebrity's is not.
+    const normalPost = await prisma.post.create({
+      data: { postedById: normal, text: 'normal' },
+    });
+    const celebPost = await prisma.post.create({
+      data: { postedById: celeb, text: 'celeb' },
+    });
+    await redis.zadd(feedKey(viewer), normalPost.id, String(normalPost.id));
+
+    const res = await request(app)
+      .get('/api/v1/posts/following')
+      .set('Authorization', authHeader(viewer));
+    const ids = (res.body as { posts: { id: number }[] }).posts.map((p) => p.id);
+
+    expect(res.status).toBe(200);
+    expect(ids).toContain(normalPost.id); // fanned out
+    expect(ids).toContain(celebPost.id); // merged in at read time
+
+    await redis.del(feedKey(viewer));
+    await prisma.post.deleteMany({
+      where: { id: { in: [normalPost.id, celebPost.id] } },
+    });
+  });
+});


### PR DESCRIPTION
## Why

The Following timeline was a pull model: every request ran `Post WHERE postedById IN (followedIds) ORDER BY id DESC`. That fan-in query is the classic home-timeline scaling problem — it degrades as people follow more accounts and as the post table grows. This builds the next step of the system-design arc: a fan-out-on-write derived feed in Redis, maintained from the CDC stream, with a read-time merge for celebrities (the hybrid model).

## What

A CDC consumer reads `owl.public.Post` and pushes each new post id into every follower's precomputed Redis feed (`feed:{userId}` ZSET, member = postId, score = postId), so the read becomes a cheap range scan of one per-user list. Celebrities (>= 10k followers) are skipped on write to avoid write amplification and merged in from Postgres at read time.

- `feed.ts` — feed key, pure `postEventEffect` (Debezium → add/remove) and `mergeFeedPages`, `getFollowedCelebrities`, and `getFollowingFeedIds` (Redis slice ⊕ celebrity DB slice).
- `getFollowingPosts` rewritten to the hybrid read, with the original pull query extracted as `getFollowingPostsFromDb` and used as the fallback (Redis cold/down, unwarmed feed, or deep page). Hydration re-checks `isDeleted`, so stale feed ids are harmless.
- `timelineFanout` consumer (`consume:feed`): ZADD on create, ZREM on soft-delete, trims to `FEED_MAX`, skips celebrities.
- `reconcileFeeds` script (`feed:reconcile`): rebuilds feeds from Postgres, optional id subset.

The feed is a cache, not the source of truth: Postgres stays authoritative and the endpoint is correct with the streaming stack off. Consumers stay local (run via `pnpm`), matching the like-counter and the "CDC not in prod for now" decision — no new compose/CI service.

## Testing

24 tests green, including new unit tests for `postEventEffect` + `mergeFeedPages` and integration tests for the Redis-hit, cold-fallback, and celebrity-merge read paths. Verified end-to-end against the live CDC stack: a normal author's post fanned out to followers and their own feed (not to non-followers), soft-deleting removed it, and a celebrity's post (user 1, 67.5k followers) was not fanned out and surfaces only via the read-time merge.

## Out of scope

For-You (`getRecommendedPosts`) is unchanged — it's a ranking problem (and separately slow); its own branch later. Next: trending via Flink.