### PR TITLE
feat: rework For-You as a ranked recommendation feed (+ covering index)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -62,8 +62,29 @@ Only the four the keyset queries actually use:
 - `Like(userId, id)` — liked feed
 - `Save(userId, id)` — saved feed
 
-Deliberately **not** added: `createdAt` or `likesCount` indexes. Every feed now
-orders by `id`, so those would never be used — dead weight on every write.
+Deliberately **not** added: a plain `createdAt` or `likesCount` *ordering* index.
+Every feed orders by `id`, so those would never be used — dead weight on every write.
+
+Later added (For-You rework): `Like(userId, createdAt, postId)` — a **covering**
+index for a specific access pattern, not feed ordering. See below.
+
+## For-You feed (measurement-driven)
+
+`EXPLAIN ANALYZE` of the old For-You query (`followed OR liked-by-followed OR
+likesCount>=3 ORDER BY id`) overturned the assumption: the `likesCount>=3` gate
+wasn't the problem (the main scan was a fast backward PK scan). The cost was the
+**social-proof subquery** — `Like WHERE userId IN (followees) ORDER BY createdAt
+DESC LIMIT 50` — doing a Bitmap Heap Scan over **~4,578 random heap blocks** to fetch
+`postId`/`createdAt`, then a sort: **~846 ms cold** (~5 ms warm, when those blocks
+are cached). No index covered "recent likes by a set of users."
+
+Fix: the covering index `Like(userId, createdAt, postId)` turns it into an
+**Index-Only Scan** (Heap Fetches ~0, ~1 ms, cache-independent).
+
+The feed was then redesigned (candidate generation → heuristic ranking), removing
+the global OR entirely; candidate sources are bounded/indexed (~1 ms social-proof,
+~0.4 ms recent-popular; followed authors O(1) from the fan-out feed when warm, or a
+~168 ms backward-PK-scan DB fallback). See `docs/for-you.md`.
 
 ## What this doesn't fix (next steps)
 

--- a/docs/for-you.md
+++ b/docs/for-you.md
@@ -1,0 +1,72 @@
+# For-You feed (candidate generation + heuristic ranking)
+
+The For-You feed is a **two-stage ranked recommendation feed**, not a chronological
+list. It replaced an earlier `WHERE followed OR liked-by-followed OR likesCount>=3
+ORDER BY id` query, which was really a candidate *filter* + reverse-chronological
+sort (no ranking; and `likesCount>=3` matched ~38% of all posts, collapsing For-You
+toward the global Hot feed).
+
+```
+candidate generation ──> ranking ──> diversity/dedup ──> page
+   (bounded sources)     (heuristic)   (per-author cap)
+```
+
+Implemented in `server/src/features/post/forYou.ts`; `getRecommendedPosts`
+(currentUserPostController.ts) is a thin controller over `getForYouFeed`.
+
+## 1. Candidate generation (bounded, Postgres-first)
+
+A pool (~a few hundred ids) from a few small sources:
+
+- **Followed authors' recent posts** — from the fan-out feed (`getFollowingFeedIds`, Redis, O(1)) when warm; DB fallback (`Post WHERE postedById IN (followees) ORDER BY id DESC`) otherwise.
+- **Social proof** — recent posts liked by followees (`Like WHERE userId IN (followees) ORDER BY createdAt DESC LIMIT 50`), plus a count of *how many* followees liked each. Rides the covering index `Like(userId, createdAt, postId)` (index-only).
+- **Discovery / popular** — recent posts with `likesCount >= POPULAR_MIN`, beyond your graph. Plus the **trending** view (`getTrendingPostIds`, Redis) when present.
+
+Union → dedupe → drop the viewer's own posts.
+
+## 2. Ranking (transparent heuristic, pure & unit-tested)
+
+```
+score = w_recency  · 0.5^(ageHours / HALF_LIFE)        // recency decay, half-life 24h
+      + w_pop      · log1p(likes + comments)            // popularity
+      + w_social   · (# followees who liked it)         // social proof
+      + w_followed · (author is followed ? 1 : 0)       // follow affinity
+      + w_trending · (in trending set ? 1 : 0)          // discovery boost
+```
+
+Weights, half-life, `POPULAR_MIN`, and pool sizes are tunable constants. Sort by
+score desc (id-desc tiebreak). **Not an ML ranker** — a weighted heuristic is the
+right complexity at this scale (no engagement training data or serving infra).
+
+## 3. Diversity & pagination
+
+- Dedupe by id; **cap per author** (max 2) so one prolific account can't flood the feed; exclude the viewer's own posts.
+- For-You is a ranked *bounded pool*, so it paginates by an **opaque offset** cursor (index into the ranked list). The client treats `nextCursor` opaquely, so no client change. Pages re-rank per request (minor drift is fine for a feed).
+
+## Why Postgres-first
+
+For-You must work in prod, which is Postgres-only (the streaming stack — and the
+Redis fan-out/trending views it populates — stays local for now). So the candidate
+sources are bounded Postgres queries by default; the Redis views (`getFollowingFeedIds`,
+`getTrendingPostIds`) are folded in **only when present**, enriching the feed without
+changing the prod path. If the streaming stack is ever productionized, For-You gets
+better automatically.
+
+## Performance (measured)
+
+`EXPLAIN ANALYZE` drove this. The original For-You's slow part was *not* the
+`likesCount>=3` gate — it was the social-proof subquery doing ~4,578 cold random
+heap reads (~846 ms cold) because no index covered "recent likes by a set of users."
+The covering index made it index-only (~1 ms). The redesign also removes the global
+OR entirely; each candidate source is bounded and indexed (the followed-authors DB
+fallback is ~168 ms on the 1M-post load-test set, and O(1) from the fan-out feed when
+warm). See `docs/benchmarks.md`.
+
+## Interview framing
+
+"Two-stage feed: candidate generation from a few bounded sources, then a transparent
+weighted ranking — recency decay + popularity + social proof + follow affinity — with
+per-author diversity. I deliberately didn't build an ML ranker (no training data /
+serving infra; a heuristic is right here). And it was measurement-driven: EXPLAIN
+showed the real bottleneck was a heap-fetch-heavy social-proof query, not the
+popularity gate I'd assumed."

--- a/server/prisma/migrations/20260605083222_like_recent_by_user_covering_index/migration.sql
+++ b/server/prisma/migrations/20260605083222_like_recent_by_user_covering_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Like_userId_createdAt_postId_idx" ON "Like"("userId", "createdAt", "postId");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -75,6 +75,10 @@ model Like {
   @@unique([userId, postId])
   // Liked feed keyset: filter by user, order by id desc.
   @@index([userId, id])
+  // Covering index for the For-You "recent likes by followees" candidate query
+  // (userId IN (...) ORDER BY createdAt DESC): postId is included so it's an
+  // index-only scan, avoiding the cold random heap reads (~846ms → index-only).
+  @@index([userId, createdAt, postId])
 }
 
 model Repost {

--- a/server/src/features/post/currentUserPostController.ts
+++ b/server/src/features/post/currentUserPostController.ts
@@ -2,23 +2,10 @@ import { Request, Response } from 'express';
 
 import { prisma } from '../../db';
 import { postQuerySchema } from '../../types/validation/schemas.js';
+import { getForYouFeed } from './forYou.js';
 import { getFollowingFeedIds } from './feed.js';
 import { withLikeCounts } from './likeCounts.js';
-
-// Shared include shape for feed posts: author summary, parent author (for reply
-// context), and the viewer's own like row (to derive isLiked).
-export function feedInclude(viewerId: number | undefined) {
-  return {
-    postedBy: { select: { id: true, username: true, name: true, profilePic: true } },
-    parentPost: { select: { postedBy: { select: { username: true } } } },
-    likes: viewerId ? { where: { userId: viewerId } } : undefined,
-  };
-}
-
-export function withIsLiked<T extends { likes?: unknown[] }>(post: T) {
-  const { likes, ...rest } = post;
-  return { ...rest, isLiked: likes ? likes.length > 0 : false };
-}
+import { feedInclude, withIsLiked } from './postSerializers.js';
 
 // The original pull model: fan-in query over followed authors. Used directly
 // when the Redis feed is cold/down, and to hydrate the merged id page below.
@@ -94,6 +81,9 @@ export async function getFollowingPosts(req: Request, res: Response) {
   }
 }
 
+// For-You: a ranked recommendation feed (candidate generation + heuristic
+// ranking), implemented in forYou.ts. The `cursor` is an opaque offset into the
+// ranked pool. This route is auth-protected, so req.user is always present.
 export async function getRecommendedPosts(req: Request, res: Response) {
   try {
     const input = postQuerySchema.safeParse(req.query);
@@ -102,92 +92,8 @@ export async function getRecommendedPosts(req: Request, res: Response) {
       return;
     }
     const { cursor, limit } = input.data;
-    const currentUserId = req.user?.id;
-
-    let followedIds: number[] = [];
-    let likedByFollowedPostIds: number[] = [];
-
-    if (currentUserId) {
-      const followedUsers = await prisma.userFollows.findMany({
-        where: { followerId: currentUserId },
-        select: { followingId: true },
-      });
-      followedIds = followedUsers.map((f) => f.followingId);
-
-      if (followedIds.length > 0) {
-        const likesByFollowed = await prisma.like.findMany({
-          where: { userId: { in: followedIds } },
-          select: { postId: true },
-          take: 50,
-          orderBy: { createdAt: 'desc' },
-        });
-        likedByFollowedPostIds = likesByFollowed.map((l) => l.postId);
-      }
-    }
-
-    const whereClause = currentUserId
-      ? {
-          isDeleted: false,
-          OR: [
-            { postedById: { in: followedIds } },
-            { id: { in: likedByFollowedPostIds } },
-            { likesCount: { gte: 3 } }, // Fallback to somewhat popular posts
-          ],
-        }
-      : { isDeleted: false };
-
-    // Fetch recommended posts
-    const recommendedPosts = await prisma.post.findMany({
-      where: { ...whereClause, ...(cursor ? { id: { lt: cursor } } : {}) },
-      orderBy: { id: 'desc' },
-      take: limit,
-      include: {
-        postedBy: {
-          select: {
-            id: true,
-            username: true,
-            name: true,
-            profilePic: true,
-          },
-        },
-        parentPost: {
-          select: {
-            postedBy: {
-              select: {
-                username: true,
-              },
-            },
-          },
-        },
-        likes: req.user
-          ? {
-              where: {
-                userId: req.user.id,
-              },
-            }
-          : undefined,
-      },
-    });
-
-    const postsWithIsLiked = recommendedPosts.map((post) => {
-      const { likes, ...rest } = post;
-      return {
-        ...rest,
-        isLiked: likes ? likes.length > 0 : false,
-      };
-    });
-
-    // Determine the next cursor for pagination
-    const nextCursor =
-      recommendedPosts.length === limit
-        ? recommendedPosts[recommendedPosts.length - 1].id
-        : null;
-
-    // Respond with recommended posts and pagination cursor
-    res.status(200).json({
-      posts: await withLikeCounts(postsWithIsLiked),
-      nextCursor,
-    });
+    const result = await getForYouFeed(req.user!.id, cursor, limit);
+    res.status(200).json(result);
   } catch (error) {
     console.error('Error in getRecommendedPosts:', error);
     res.status(500).json({ error: 'An unknown error occurred' });

--- a/server/src/features/post/forYou.ts
+++ b/server/src/features/post/forYou.ts
@@ -1,0 +1,166 @@
+// For-You feed: a two-stage ranked recommendation feed.
+//   1. candidate generation — gather a bounded pool from a few sources
+//   2. ranking — score each candidate with a transparent weighted heuristic
+//   3. diversity/dedup — cap per author, drop the viewer's own posts
+//
+// Postgres-first (so it runs the same in prod, no Redis required); the Redis
+// trending view is folded in as an extra discovery source only when present.
+// Not an ML ranker — a heuristic is the right complexity at this scale.
+
+import { prisma } from '../../db/index.js';
+import { withLikeCounts } from './likeCounts.js';
+import { feedInclude, withIsLiked } from './postSerializers.js';
+import { getTrendingPostIds } from './trending.js';
+
+// --- Tunables ---
+const POOL = { followed: 100, social: 50, popular: 50 }; // per-source candidate caps
+const POPULAR_MIN = 3; // "recent popular" like threshold for discovery candidates
+const HALF_LIFE_HOURS = 24; // recency score halves every day
+const MAX_PER_AUTHOR = 2; // diversity cap in the ranked output
+const WEIGHTS = {
+  recency: 3,
+  popularity: 1,
+  social: 2, // per followee who liked it
+  followed: 1.5,
+  trending: 1,
+};
+
+export type Signals = {
+  isFollowed: boolean;
+  socialProofCount: number; // how many of the viewer's followees liked it
+  isTrending: boolean;
+};
+
+export type RankablePost = {
+  id: number;
+  postedById: number;
+  createdAt: Date | string;
+  likesCount: number;
+  commentsCount: number;
+};
+
+function recencyDecay(ageHours: number): number {
+  return Math.pow(0.5, Math.max(0, ageHours) / HALF_LIFE_HOURS);
+}
+
+/** Transparent weighted score. Pure — unit-tested. */
+export function scorePost(post: RankablePost, sig: Signals, now: number): number {
+  const ageHours = (now - new Date(post.createdAt).getTime()) / 3_600_000;
+  return (
+    WEIGHTS.recency * recencyDecay(ageHours) +
+    WEIGHTS.popularity * Math.log1p(post.likesCount + post.commentsCount) +
+    WEIGHTS.social * sig.socialProofCount +
+    WEIGHTS.followed * (sig.isFollowed ? 1 : 0) +
+    WEIGHTS.trending * (sig.isTrending ? 1 : 0)
+  );
+}
+
+/**
+ * Rank candidates by score (desc, id-desc tiebreak) and apply a per-author
+ * diversity cap. Pure — unit-tested.
+ */
+export function rankCandidates<T extends RankablePost>(
+  candidates: { post: T; signals: Signals }[],
+  now: number = Date.now(),
+): T[] {
+  const scored = candidates
+    .map(({ post, signals }) => ({ post, score: scorePost(post, signals, now) }))
+    .sort((a, b) => b.score - a.score || b.post.id - a.post.id);
+
+  const perAuthor = new Map<number, number>();
+  const out: T[] = [];
+  for (const { post } of scored) {
+    const seen = perAuthor.get(post.postedById) ?? 0;
+    if (seen >= MAX_PER_AUTHOR) continue;
+    perAuthor.set(post.postedById, seen + 1);
+    out.push(post);
+  }
+  return out;
+}
+
+/**
+ * Build the For-You feed for a viewer. `offset` is the opaque cursor (index into
+ * the ranked pool); the pool is bounded, so this is a handful of pages.
+ */
+export async function getForYouFeed(
+  viewerId: number,
+  offset: number,
+  limit: number,
+) {
+  const follows = await prisma.userFollows.findMany({
+    where: { followerId: viewerId },
+    select: { followingId: true },
+  });
+  const followedIds = follows.map((f) => f.followingId);
+  const followedSet = new Set(followedIds);
+
+  // --- Candidate generation: bounded, mostly indexed queries ---
+  const [followedPosts, socialLikes, popularPosts, trendingIds] =
+    await Promise.all([
+      followedIds.length
+        ? prisma.post.findMany({
+            where: { postedById: { in: followedIds }, isDeleted: false },
+            orderBy: { id: 'desc' },
+            take: POOL.followed,
+            select: { id: true },
+          })
+        : [],
+      followedIds.length
+        ? prisma.like.findMany({
+            where: { userId: { in: followedIds } },
+            orderBy: { createdAt: 'desc' },
+            take: POOL.social,
+            select: { postId: true },
+          })
+        : [],
+      prisma.post.findMany({
+        where: { isDeleted: false, likesCount: { gte: POPULAR_MIN } },
+        orderBy: { id: 'desc' },
+        take: POOL.popular,
+        select: { id: true },
+      }),
+      getTrendingPostIds(POOL.popular), // null when Redis is cold/down
+    ]);
+
+  // Social-proof strength: how many followees liked each candidate.
+  const socialCount = new Map<number, number>();
+  for (const { postId } of socialLikes) {
+    socialCount.set(postId, (socialCount.get(postId) ?? 0) + 1);
+  }
+  const trendingSet = new Set(trendingIds ?? []);
+
+  const candidateIds = new Set<number>([
+    ...followedPosts.map((p) => p.id),
+    ...socialLikes.map((l) => l.postId),
+    ...popularPosts.map((p) => p.id),
+    ...(trendingIds ?? []),
+  ]);
+  if (candidateIds.size === 0) return { posts: [], nextCursor: null };
+
+  // --- Hydrate + real like counts (Redis-or-DB) ---
+  const rows = await prisma.post.findMany({
+    where: { id: { in: [...candidateIds] }, isDeleted: false },
+    include: feedInclude(viewerId),
+  });
+  await withLikeCounts(rows); // mutates likesCount in place to the served value
+
+  // --- Attach signals, drop own posts, rank ---
+  const candidates = rows
+    .filter((p) => p.postedById !== viewerId)
+    .map((post) => ({
+      post,
+      signals: {
+        isFollowed: followedSet.has(post.postedById),
+        socialProofCount: socialCount.get(post.id) ?? 0,
+        isTrending: trendingSet.has(post.id),
+      },
+    }));
+
+  const ranked = rankCandidates(candidates);
+
+  // --- Offset pagination over the ranked pool (counts already applied above) ---
+  const page = ranked.slice(offset, offset + limit).map(withIsLiked);
+  const nextCursor = offset + limit < ranked.length ? offset + limit : null;
+
+  return { posts: page, nextCursor };
+}

--- a/server/src/features/post/forYou.ts
+++ b/server/src/features/post/forYou.ts
@@ -8,6 +8,7 @@
 // Not an ML ranker — a heuristic is the right complexity at this scale.
 
 import { prisma } from '../../db/index.js';
+import { getFollowingFeedIds } from './feed.js';
 import { withLikeCounts } from './likeCounts.js';
 import { feedInclude, withIsLiked } from './postSerializers.js';
 import { getTrendingPostIds } from './trending.js';
@@ -95,16 +96,11 @@ export async function getForYouFeed(
   const followedSet = new Set(followedIds);
 
   // --- Candidate generation: bounded, mostly indexed queries ---
-  const [followedPosts, socialLikes, popularPosts, trendingIds] =
+  const [followedFeedIds, socialLikes, popularPosts, trendingIds] =
     await Promise.all([
-      followedIds.length
-        ? prisma.post.findMany({
-            where: { postedById: { in: followedIds }, isDeleted: false },
-            orderBy: { id: 'desc' },
-            take: POOL.followed,
-            select: { id: true },
-          })
-        : [],
+      // Followed authors' recent posts: prefer the precomputed fan-out feed
+      // (O(1) Redis read); null when Redis is cold/down → DB fallback below.
+      getFollowingFeedIds(viewerId, 0, POOL.followed),
       followedIds.length
         ? prisma.like.findMany({
             where: { userId: { in: followedIds } },
@@ -122,6 +118,20 @@ export async function getForYouFeed(
       getTrendingPostIds(POOL.popular), // null when Redis is cold/down
     ]);
 
+  // DB fallback for followed candidates when the fan-out feed isn't available.
+  const followedPostIds =
+    followedFeedIds ??
+    (followedIds.length
+      ? (
+          await prisma.post.findMany({
+            where: { postedById: { in: followedIds }, isDeleted: false },
+            orderBy: { id: 'desc' },
+            take: POOL.followed,
+            select: { id: true },
+          })
+        ).map((p) => p.id)
+      : []);
+
   // Social-proof strength: how many followees liked each candidate.
   const socialCount = new Map<number, number>();
   for (const { postId } of socialLikes) {
@@ -130,7 +140,7 @@ export async function getForYouFeed(
   const trendingSet = new Set(trendingIds ?? []);
 
   const candidateIds = new Set<number>([
-    ...followedPosts.map((p) => p.id),
+    ...followedPostIds,
     ...socialLikes.map((l) => l.postId),
     ...popularPosts.map((p) => p.id),
     ...(trendingIds ?? []),

--- a/server/src/features/post/postSerializers.ts
+++ b/server/src/features/post/postSerializers.ts
@@ -1,0 +1,18 @@
+// Shared shapes for serializing posts in feed/list responses. Lives in its own
+// module so the controllers, the trending view, and the For-You feed can all
+// reuse it without importing each other (avoids circular imports).
+
+// Include shape for feed posts: author summary, parent author (for reply
+// context), and the viewer's own like row (to derive isLiked).
+export function feedInclude(viewerId: number | undefined) {
+  return {
+    postedBy: { select: { id: true, username: true, name: true, profilePic: true } },
+    parentPost: { select: { postedBy: { select: { username: true } } } },
+    likes: viewerId ? { where: { userId: viewerId } } : undefined,
+  };
+}
+
+export function withIsLiked<T extends { likes?: unknown[] }>(post: T) {
+  const { likes, ...rest } = post;
+  return { ...rest, isLiked: likes ? likes.length > 0 : false };
+}

--- a/server/src/features/post/trending.ts
+++ b/server/src/features/post/trending.ts
@@ -9,7 +9,7 @@
 
 import { prisma } from '../../db/index.js';
 import { redis } from '../../redis.js';
-import { feedInclude, withIsLiked } from './currentUserPostController.js';
+import { feedInclude, withIsLiked } from './postSerializers.js';
 import { withLikeCounts } from './likeCounts.js';
 
 export const TRENDING_KEY = 'trending';

--- a/server/src/test/forYou.test.ts
+++ b/server/src/test/forYou.test.ts
@@ -1,0 +1,120 @@
+import request from 'supertest';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { app } from '../app.js';
+import { prisma } from '../db/index.js';
+import { rankCandidates, scorePost, Signals } from '../features/post/forYou.js';
+import { authHeader, createUser, resetDb } from './helpers.js';
+
+const NOW = Date.UTC(2026, 0, 1, 12, 0, 0);
+const noSignals: Signals = {
+  isFollowed: false,
+  socialProofCount: 0,
+  isTrending: false,
+};
+
+function post(id: number, over: Partial<Parameters<typeof scorePost>[0]> = {}) {
+  return {
+    id,
+    postedById: id, // unique author per post unless overridden
+    createdAt: new Date(NOW),
+    likesCount: 0,
+    commentsCount: 0,
+    ...over,
+  };
+}
+
+describe('scorePost (pure ranking heuristic)', () => {
+  it('rewards popularity, social proof, follow, and trending', () => {
+    const base = scorePost(post(1), noSignals, NOW);
+    expect(scorePost(post(1, { likesCount: 100 }), noSignals, NOW)).toBeGreaterThan(base);
+    expect(scorePost(post(1), { ...noSignals, socialProofCount: 3 }, NOW)).toBeGreaterThan(base);
+    expect(scorePost(post(1), { ...noSignals, isFollowed: true }, NOW)).toBeGreaterThan(base);
+    expect(scorePost(post(1), { ...noSignals, isTrending: true }, NOW)).toBeGreaterThan(base);
+  });
+
+  it('decays with age', () => {
+    const fresh = scorePost(post(1, { createdAt: new Date(NOW) }), noSignals, NOW);
+    const old = scorePost(
+      post(1, { createdAt: new Date(NOW - 7 * 24 * 3600_000) }),
+      noSignals,
+      NOW,
+    );
+    expect(fresh).toBeGreaterThan(old);
+  });
+});
+
+describe('rankCandidates', () => {
+  it('orders by score descending', () => {
+    const ranked = rankCandidates(
+      [
+        { post: post(1, { postedById: 1 }), signals: noSignals },
+        { post: post(2, { postedById: 2 }), signals: { ...noSignals, socialProofCount: 5 } },
+        { post: post(3, { postedById: 3 }), signals: { ...noSignals, isFollowed: true } },
+      ],
+      NOW,
+    );
+    expect(ranked[0].id).toBe(2); // highest social proof wins
+  });
+
+  it('caps posts per author for diversity', () => {
+    const flood = [1, 2, 3, 4].map((id) => ({
+      post: post(id, { postedById: 99, likesCount: 100 }),
+      signals: noSignals,
+    }));
+    const other = { post: post(5, { postedById: 7 }), signals: noSignals };
+    const ranked = rankCandidates([...flood, other], NOW);
+    expect(ranked.filter((p) => p.postedById === 99)).toHaveLength(2);
+    expect(ranked.map((p) => p.id)).toContain(5);
+  });
+});
+
+describe('GET /posts/for-you (ranked feed)', () => {
+  let viewer: number;
+  let alice: number;
+  let pOwn: number;
+  let pFollowedOld: number;
+  let pPopularSocial: number;
+
+  beforeAll(async () => {
+    await resetDb();
+    viewer = await createUser('viewer');
+    alice = await createUser('alice'); // followed
+    const carol = await createUser('carol'); // not followed (discovery)
+    await prisma.userFollows.create({
+      data: { followerId: viewer, followingId: alice },
+    });
+
+    pOwn = (await prisma.post.create({ data: { postedById: viewer, text: 'mine' } })).id;
+    pFollowedOld = (
+      await prisma.post.create({
+        data: {
+          postedById: alice,
+          text: 'old followed',
+          createdAt: new Date(Date.now() - 10 * 24 * 3600_000),
+        },
+      })
+    ).id;
+    // Not followed, but popular AND liked by a followee → should rank highly.
+    pPopularSocial = (
+      await prisma.post.create({
+        data: { postedById: carol, text: 'popular', likesCount: 8 },
+      })
+    ).id;
+    await prisma.like.create({ data: { userId: alice, postId: pPopularSocial } });
+  });
+
+  it('ranks, excludes own posts, and surfaces popular+social above stale follows', async () => {
+    const res = await request(app)
+      .get('/api/v1/posts/for-you')
+      .set('Authorization', authHeader(viewer));
+    const ids = (res.body as { posts: { id: number }[] }).posts.map((p) => p.id);
+
+    expect(res.status).toBe(200);
+    expect(ids).not.toContain(pOwn); // own posts excluded
+    expect(ids).toContain(pFollowedOld); // followed candidate present
+    expect(ids).toContain(pPopularSocial); // discovery candidate present
+    // popular + social-proof + fresh beats a stale followed post
+    expect(ids.indexOf(pPopularSocial)).toBeLessThan(ids.indexOf(pFollowedOld));
+  });
+});


### PR DESCRIPTION
## Why
The For-You feed was logic I wasn't confident in: a candidate *filter* + reverse-chronological sort (`followed OR liked-by-followed OR likesCount>=3 ORDER BY id`). It had no real ranking, and the `likesCount>=3` gate matched ~38% of all posts, so For-You collapsed toward the global Hot feed. EXPLAIN ANALYZE also showed it was slow — but not where I assumed.

## What
Redesign For-You as the standard two-stage feed:
- **Candidate generation** (bounded, Postgres-first): followed authors (from the fan-out feed when warm, DB fallback otherwise), social-proof likes (recent posts liked by people you follow), recent-popular, and the Redis trending view when present.
- **Ranking**: a transparent weighted heuristic — recency decay + popularity + social-proof count + follow affinity + trending boost (pure, unit-tested). Not an ML ranker; a heuristic is the right complexity here.
- **Diversity/pagination**: per-author cap, own-post exclusion, opaque offset cursor (no client change).

It's Postgres-first so it runs the same in prod; the Redis views enrich it only when present.

## Performance (measured)
EXPLAIN showed the bottleneck wasn't `likesCount>=3` — it was the social-proof subquery (`Like WHERE userId IN (followees) ORDER BY createdAt DESC`) doing ~4,578 cold random heap reads (~846ms cold). Added a covering index `Like(userId, createdAt, postId)` → index-only scan (~1ms). The redesign removes the global OR entirely; candidate sources are bounded/indexed.

## Testing
31 server tests green, including pure `scorePost`/`rankCandidates` unit tests and a `/for-you` integration test (ranked order, own-post exclusion, popular+social ranking above stale follows). Verified on the 1M-post dev DB: ranked + paginated; recency decay correctly demotes an old high-like post below recent trending ones.