### PR TITLE
feat: empty-state for the Following feed

### DIFF
--- a/client/src/features/posts/FollowingEmpty/FollowingEmpty.tsx
+++ b/client/src/features/posts/FollowingEmpty/FollowingEmpty.tsx
@@ -1,0 +1,49 @@
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+
+import { axiosInstance } from '@/api/axiosConfig.ts';
+import { SearchUser, UserItem } from '@/features/user/UserItem/UserItem.tsx';
+import { Box, Button, Stack, Text } from '@mantine/core';
+
+type RecommendedResponse = { users: SearchUser[] };
+
+// Shown when the Following timeline is empty (a new user, or one who follows
+// nobody). Keeps Following purely chronological — discovery lives in Explore —
+// while giving a dead feed a useful next step: people to follow.
+export function FollowingEmpty() {
+  const { data } = useQuery({
+    queryKey: ['recommendedUsers'],
+    queryFn: async () =>
+      (await axiosInstance.get<RecommendedResponse>('users/recommended')).data,
+  });
+
+  return (
+    <Stack p="md" gap="lg">
+      <Stack gap={6} ta="center" mt="xl">
+        <Text fw={700} size="lg">
+          Your timeline is empty
+        </Text>
+        <Text c="dimmed" size="sm">
+          Follow people to see their posts here — or head to Explore to see
+          what&apos;s popular right now.
+        </Text>
+        <Box mt="xs">
+          <Button component={Link} to="/search" radius="xl" variant="default">
+            Go to Explore
+          </Button>
+        </Box>
+      </Stack>
+
+      {(data?.users.length ?? 0) > 0 && (
+        <Box>
+          <Text fw={700} size="sm" c="dimmed" mb="xs">
+            Suggested for you
+          </Text>
+          {data?.users.slice(0, 5).map((user) => (
+            <UserItem key={user.id} user={user} />
+          ))}
+        </Box>
+      )}
+    </Stack>
+  );
+}

--- a/client/src/features/posts/PostList/PostList.tsx
+++ b/client/src/features/posts/PostList/PostList.tsx
@@ -1,10 +1,12 @@
 import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useInView } from 'react-intersection-observer';
 
 import { Loading } from '@/components/Loading/Loading.tsx';
 import { usePosts } from '@/hooks/usePosts.tsx';
 import { Center, Loader, Stack } from '@mantine/core';
 
+import { FollowingEmpty } from '../FollowingEmpty/FollowingEmpty.tsx';
 import { PostItem } from '../PostItem/PostItem.tsx';
 
 type PostListProps = {
@@ -15,6 +17,7 @@ export function PostList({ endpoint }: PostListProps) {
   const { data, isPending, isError, hasNextPage, fetchNextPage, isFetching } =
     usePosts(endpoint);
   const { ref, inView } = useInView();
+  const location = useLocation();
 
   useEffect(() => {
     if (inView && hasNextPage) {
@@ -28,6 +31,14 @@ export function PostList({ endpoint }: PostListProps) {
 
   if (isError) {
     return <div>Error loading posts</div>;
+  }
+
+  // Empty Following timeline → suggest people to follow (keeps Following
+  // chronological; discovery stays in Explore/For-You).
+  const feed = endpoint ?? location.pathname;
+  const isEmpty = !!data && data.pages.every((page) => page.posts.length === 0);
+  if (isEmpty && feed === '/following') {
+    return <FollowingEmpty />;
   }
 
   return (


### PR DESCRIPTION
## Why
The For-You feed was logic I wasn't confident in: a candidate *filter* + reverse-chronological sort (`followed OR liked-by-followed OR likesCount>=3 ORDER BY id`). It had no real ranking, and the `likesCount>=3` gate matched ~38% of all posts, so For-You collapsed toward the global Hot feed. EXPLAIN ANALYZE also showed it was slow — but not where I assumed.

## What
Redesign For-You as the standard two-stage feed:
- **Candidate generation** (bounded, Postgres-first): followed authors (from the fan-out feed when warm, DB fallback otherwise), social-proof likes (recent posts liked by people you follow), recent-popular, and the Redis trending view when present.
- **Ranking**: a transparent weighted heuristic — recency decay + popularity + social-proof count + follow affinity + trending boost (pure, unit-tested). Not an ML ranker; a heuristic is the right complexity here.
- **Diversity/pagination**: per-author cap, own-post exclusion, opaque offset cursor (no client change).

It's Postgres-first so it runs the same in prod; the Redis views enrich it only when present.

## Performance (measured)
EXPLAIN showed the bottleneck wasn't `likesCount>=3` — it was the social-proof subquery (`Like WHERE userId IN (followees) ORDER BY createdAt DESC`) doing ~4,578 cold random heap reads (~846ms cold). Added a covering index `Like(userId, createdAt, postId)` → index-only scan (~1ms). The redesign removes the global OR entirely; candidate sources are bounded/indexed.

## Testing
31 server tests green, including pure `scorePost`/`rankCandidates` unit tests and a `/for-you` integration test (ranked order, own-post exclusion, popular+social ranking above stale follows). Verified on the 1M-post dev DB: ranked + paginated; recency decay correctly demotes an old high-like post below recent trending ones.