### PR TITLE
feat(auth): stateful refresh tokens — rotation + reuse detection via Redis

### DIFF
--- a/client/src/utils/refreshAccessToken.ts
+++ b/client/src/utils/refreshAccessToken.ts
@@ -1,9 +1,15 @@
 import { AuthResponse, axiosInstance } from '@/api/axiosConfig.ts';
 import { useAuthStore } from '@stores/authStore.ts';
 
-export async function refreshAccessToken() {
+// Single-flight: refresh tokens now rotate on the server, so two concurrent
+// refreshes would present the same (now-stale-after-the-first) token and trip
+// reuse detection — logging the user out. Share one in-flight refresh instead.
+let inFlight: Promise<string | null> | null = null;
+
+async function doRefresh(): Promise<string | null> {
   try {
-    const response = await axiosInstance.get<AuthResponse>(
+    // POST: refresh rotates server state (issues a new refresh cookie).
+    const response = await axiosInstance.post<AuthResponse>(
       '/auth/refresh-token',
     );
 
@@ -17,4 +23,11 @@ export async function refreshAccessToken() {
     useAuthStore.getState().setAccessToken(null);
     return null;
   }
+}
+
+export function refreshAccessToken(): Promise<string | null> {
+  inFlight ??= doRefresh().finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,20 @@ services:
     volumes:
       - pg_data:/var/lib/postgresql/data
 
+  # Session store for stateful refresh tokens. Persisted so sessions survive
+  # restarts; auth fails closed if it's unavailable.
+  redis:
+    image: redis:7-alpine
+    networks: [appnet]
+    restart: always
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    volumes:
+      - redis_data:/data
+
   server:
     image: ghcr.io/ulixert/owl-server:latest
     env_file:
@@ -23,8 +37,12 @@ services:
       # Where DiskStorage writes uploads; backed by the named volume below so
       # images survive container restarts and redeploys.
       UPLOAD_DIR: /app/uploads
+      # Stateful refresh-token sessions (see docs/auth-sessions.md).
+      REDIS_URL: redis://redis:6379
     depends_on:
       db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     networks: [appnet]
     restart: unless-stopped
@@ -81,3 +99,4 @@ networks:
 volumes:
   pg_data:
   uploads:
+  redis_data:

--- a/docs/auth-sessions.md
+++ b/docs/auth-sessions.md
@@ -1,0 +1,70 @@
+# Auth: stateful refresh tokens (rotation + reuse detection)
+
+Access tokens stay **stateless** (15-min JWT, in client memory). The **refresh**
+token is now **stateful**, backed by a Redis session store, which makes it
+revocable, rotating, and reuse-detectable — things a plain JWT can't do.
+
+```
+login/signup ──> create session family (Redis: refresh:{familyId} = jti, TTL 7d)
+                 set refresh cookie (httpOnly JWT carrying familyId + jti)
+
+POST /auth/refresh-token (cookie) ──> verify JWT, then check Redis:
+   familyId missing        → 401 (revoked / expired / logged out)
+   jti ≠ stored jti        → REUSE: DEL family, 401  (a rotated-out token replayed)
+   jti == stored jti       → rotate: new jti, reset TTL, set new cookie, new access token
+
+POST /auth/logout (cookie) ──> DEL refresh:{familyId}, clear cookie
+```
+
+## Why
+
+A stateless refresh JWT can't be revoked — logout only clears the cookie, so a
+**stolen** refresh token works until it expires (7 days). Making it stateful gives:
+
+- **Revocation / real logout** — delete the family from Redis.
+- **Rotation** — every refresh issues a new token and invalidates the old one, so a
+  leaked token has a tiny useful lifetime.
+- **Reuse detection** — if an *already-rotated* token is presented (only possible if
+  it was captured), that's a theft signal → revoke the whole family, forcing re-login.
+  This is the OAuth "refresh token rotation with reuse detection" BCP.
+
+## Model
+
+- Refresh JWT payload: `userId, username, name, profilePic, familyId, jti`.
+- `familyId` = one login/session; `jti` = this specific token. Redis stores
+  `refresh:{familyId}` → the single currently-valid `jti` (TTL 7d).
+- The token is gated **both** by JWT signature **and** by the Redis check — signature
+  alone proves authenticity, Redis proves it hasn't been rotated out or revoked.
+
+Files: `server/src/features/auth/session.ts` (Redis helpers: `createSession`,
+`rotateSession`, `revokeSession`), `authController.ts` (login/signup/refresh/logout),
+`utils/generateTokenAndSetCookie.ts` (`issueRefreshToken`).
+
+## Fail closed
+
+Auth treats any Redis error as failure (→ 401/500); it never falls back to accepting
+a token statelessly. A down Redis must not silently bypass revocation. The trade-off:
+Redis is now a hard dependency for login/refresh/logout — hence it's in the prod
+compose (`docker-compose.yml`), and `server/.prod.env` must set
+`REDIS_URL=redis://redis:6379`.
+
+## Concurrency
+
+Rotation + two concurrent refreshes is a hazard: the first rotates the jti, the
+second still holds the old one → false reuse detection → unwanted logout. The client
+(`refreshAccessToken.ts`) uses **single-flight** — one shared in-flight refresh — so
+concurrent 401s don't fire parallel refreshes. (A short server-side grace window for
+the immediately-previous jti is an alternative; not implemented.)
+
+## Verified
+
+`server/src/test/authSession.test.ts`: refresh rotates (old token rejected); replaying
+a rotated-out token → 401 **and** the family is revoked (the current token then also
+fails); logout → subsequent refresh 401; missing token → 401.
+
+## Out of scope / next
+
+- **Per-user session list / "log out everywhere"** — would need an index of a user's
+  families (e.g. a Redis set keyed by userId). Easy extension on this model.
+- **Access-token denylist** — access tokens stay stateless, so a compromised one is
+  valid until it expires (15 min); a denylist would close that window if needed.

--- a/server/src/features/auth/authController.ts
+++ b/server/src/features/auth/authController.ts
@@ -1,140 +1,140 @@
 import { Request, Response } from 'express';
-import jwt from 'jsonwebtoken';
 import { LoginSchema, UserCreateSchema } from 'validation';
 
 import argon2 from '@node-rs/argon2';
 
 import { prisma } from '../../db';
+import { JWTError } from '../../errors/errors.js';
 import { jwtVerify } from '../../middlewares/utils/jwtVerify.js';
 import {
   generateAccessToken,
-  generateRefreshTokenAndSetCookie,
+  issueRefreshToken,
 } from '../../utils/generateTokenAndSetCookie.js';
+import { createSession, revokeSession, rotateSession } from './session.js';
 import { checkPassword } from './utils/checkPassword.js';
+
+type AuthUser = {
+  id: number;
+  username: string;
+  name: string;
+  profilePic: string | null;
+};
+
+// Start a session, set the rotating refresh cookie, and return the auth payload.
+async function issueSession(res: Response, user: AuthUser) {
+  const { familyId, jti } = await createSession();
+  issueRefreshToken(res, {
+    userId: user.id,
+    username: user.username,
+    name: user.name,
+    profilePic: user.profilePic,
+    familyId,
+    jti,
+  });
+  return {
+    accessToken: generateAccessToken(user.id),
+    userId: user.id,
+    username: user.username,
+    name: user.name,
+    profilePic: user.profilePic,
+  };
+}
 
 export async function login(req: Request, res: Response) {
   try {
-    // Validate input
     const input = LoginSchema.safeParse(req.body);
     if (!input.success) {
-      res.status(400).json({
-        message: 'Invalid user data',
-      });
+      res.status(400).json({ message: 'Invalid user data' });
       return;
     }
 
     const { email, password } = input.data;
     const user = await prisma.user.findUnique({
       where: { email },
-      select: { password: true, id: true, username: true, name: true, profilePic: true },
+      select: {
+        password: true,
+        id: true,
+        username: true,
+        name: true,
+        profilePic: true,
+      },
     });
     if (!user) {
-      res.status(400).json({
-        message: 'Invalid email or password',
-      });
+      res.status(400).json({ message: 'Invalid email or password' });
       return;
     }
 
-    // Check if password is correct
     const isPasswordCorrect = await checkPassword(user.password, password);
     if (!isPasswordCorrect) {
-      res.status(400).json({
-        message: 'Invalid email or password',
-      });
+      res.status(400).json({ message: 'Invalid email or password' });
       return;
     }
 
-    // Generate tokens
-    generateRefreshTokenAndSetCookie(
-      res,
-      user.id,
-      user.username,
-      user.name,
-      user.profilePic,
-    );
-    res.status(200).json({
-      accessToken: generateAccessToken(user.id),
-      userId: user.id,
-      username: user.username,
-      name: user.name,
-      profilePic: user.profilePic,
-    });
+    res.status(200).json(await issueSession(res, user));
   } catch (error) {
     res.status(500).json({ message: 'An unknown error occurred.' });
     console.error('Error in login: ', error);
   }
 }
 
-export function logout(_req: Request, res: Response) {
-  try {
-    res.clearCookie('refreshToken').status(204).send();
-  } catch (error) {
-    res.status(500).json({
-      message: 'An unknown error occurred.',
-    });
-    console.error('Error in logout: ', error);
-  }
-}
-
 export async function signup(req: Request, res: Response) {
   try {
-    // Validate input
     const input = UserCreateSchema.safeParse(req.body);
     if (!input.success) {
       res.status(400).json({ message: 'Invalid user data' });
       return;
     }
 
-    // Check if user already exists
     const { username, email, password, name } = input.data;
     const existingUser = await prisma.user.findFirst({
-      where: {
-        OR: [{ email }, { username }],
-      },
+      where: { OR: [{ email }, { username }] },
     });
-
     if (existingUser) {
-      res.status(400).json({
-        message: 'User already exists',
-      });
+      res.status(400).json({ message: 'User already exists' });
       return;
     }
 
-    // Create new user
     const hashedPassword = await argon2.hash(password);
-
     const newUser = await prisma.user.create({
-      data: {
-        email,
-        username,
-        password: hashedPassword,
-        name,
-      },
+      data: { email, username, password: hashedPassword, name },
     });
 
-    generateRefreshTokenAndSetCookie(
-      res,
-      newUser.id,
-      newUser.username,
-      newUser.name,
-      newUser.profilePic,
-    );
-    res.status(201).json({
-      accessToken: generateAccessToken(newUser.id),
-      userId: newUser.id,
-      username: newUser.username,
-      name: newUser.name,
-      profilePic: newUser.profilePic,
-    });
+    res.status(201).json(await issueSession(res, newUser));
   } catch (error) {
-    res.status(500).json({
-      message: 'An unknown error occurred.',
-    });
+    res.status(500).json({ message: 'An unknown error occurred.' });
     console.error('Error in signup: ', error);
   }
 }
 
-// Token Refresh Function
+// Best-effort revoke: kill the session family in Redis, then always clear the
+// cookie (even if the token is unverifiable, so the client ends up logged out).
+export async function logout(req: Request, res: Response) {
+  try {
+    const token =
+      typeof req.cookies?.refreshToken === 'string'
+        ? req.cookies.refreshToken
+        : undefined;
+    if (token) {
+      try {
+        const { familyId } = await jwtVerify(
+          token,
+          process.env.REFRESH_TOKEN_SECRET!,
+        );
+        if (familyId) await revokeSession(familyId);
+      } catch {
+        // ignore — clear the cookie regardless
+      }
+    }
+    res.clearCookie('refreshToken').status(204).send();
+  } catch (error) {
+    res.status(500).json({ message: 'An unknown error occurred.' });
+    console.error('Error in logout: ', error);
+  }
+}
+
+// Rotating refresh: verify the JWT, then require its jti to match the family's
+// current jti in Redis. Match → rotate (new jti + cookie). Stale jti → reuse
+// detected (the family is revoked). Missing family → revoked/expired/logged out.
 export async function refreshAccessToken(req: Request, res: Response) {
   try {
     const token =
@@ -142,36 +142,56 @@ export async function refreshAccessToken(req: Request, res: Response) {
         ? req.cookies.refreshToken
         : undefined;
     if (!token) {
+      res.status(401).json({ message: 'Refresh token not found' });
+      return;
+    }
+
+    let payload;
+    try {
+      payload = await jwtVerify(token, process.env.REFRESH_TOKEN_SECRET!);
+    } catch (err) {
+      if (err instanceof JWTError) {
+        res.status(401).json({ message: 'Invalid or expired refresh token.' });
+        return;
+      }
+      throw err;
+    }
+
+    const { userId, username, name, profilePic, familyId, jti } = payload;
+    if (!familyId || !jti) {
+      // Pre-rotation token (no session) — force a fresh login.
+      res.status(401).json({ message: 'Please log in again.' });
+      return;
+    }
+
+    const result = await rotateSession(familyId, jti);
+    if (result.status !== 'rotated') {
       res.status(401).json({
-        message: 'Refresh token not found',
+        message:
+          result.status === 'reuse'
+            ? 'Refresh token reuse detected. Please log in again.'
+            : 'Session expired. Please log in again.',
       });
       return;
     }
 
-    const { userId, username, name, profilePic } = await jwtVerify(
-      token,
-      process.env.REFRESH_TOKEN_SECRET!,
-    );
-
-    const accessToken = generateAccessToken(userId);
-
-    res.status(200).json({ accessToken, userId, username, name, profilePic });
-  } catch (error) {
-    if (error instanceof jwt.TokenExpiredError) {
-      res.status(401).json({
-        message: 'Refresh token expired. Please log in again.',
-      });
-      return;
-    } else if (error instanceof jwt.JsonWebTokenError) {
-      res.status(401).json({
-        message: 'Invalid refresh token. Please log in again.',
-      });
-      return;
-    }
-
-    console.error('Error in refreshAccessToken:', error);
-    res.status(500).json({
-      message: 'An unknown error occurred.',
+    issueRefreshToken(res, {
+      userId,
+      username,
+      name,
+      profilePic,
+      familyId,
+      jti: result.jti,
     });
+    res.status(200).json({
+      accessToken: generateAccessToken(userId),
+      userId,
+      username,
+      name,
+      profilePic,
+    });
+  } catch (error) {
+    console.error('Error in refreshAccessToken:', error);
+    res.status(500).json({ message: 'An unknown error occurred.' });
   }
 }

--- a/server/src/features/auth/authRouter.ts
+++ b/server/src/features/auth/authRouter.ts
@@ -7,4 +7,5 @@ export const authRouter: Router = Router();
 authRouter.post('/signup', signup);
 authRouter.post('/login', login);
 authRouter.post('/logout', logout);
-authRouter.get('/refresh-token', refreshAccessToken);
+// POST: rotation mutates server state (issues a new refresh token).
+authRouter.post('/refresh-token', refreshAccessToken);

--- a/server/src/features/auth/session.ts
+++ b/server/src/features/auth/session.ts
@@ -1,0 +1,57 @@
+// Stateful refresh-token sessions in Redis. Each login starts a "family" (one
+// session); the refresh token carries familyId + jti, and Redis holds the single
+// jti currently valid for that family. This is what makes refresh tokens
+// revocable (logout), rotating (new jti each refresh), and reuse-detectable
+// (replaying a rotated-out jti revokes the whole family — a theft signal).
+//
+// Auth fails CLOSED: callers let Redis errors propagate (→ 401/500), never
+// falling back to stateless acceptance, so a down Redis can't bypass revocation.
+
+import { randomUUID } from 'node:crypto';
+
+import { redis } from '../../redis.js';
+
+const TTL_SECONDS = 7 * 24 * 60 * 60; // matches the 7-day refresh cookie
+
+export const familyKey = (familyId: string) => `refresh:${familyId}`;
+
+export type SessionToken = { familyId: string; jti: string };
+
+export type RotateResult =
+  | { status: 'rotated'; jti: string }
+  | { status: 'reuse' }
+  | { status: 'missing' };
+
+/** Start a new session family with its first token. */
+export async function createSession(): Promise<SessionToken> {
+  const familyId = randomUUID();
+  const jti = randomUUID();
+  await redis.set(familyKey(familyId), jti, 'EX', TTL_SECONDS);
+  return { familyId, jti };
+}
+
+/**
+ * Rotate the family's token. Only the *current* jti may rotate:
+ *  - no family record  → 'missing' (revoked / expired / logged out)
+ *  - jti is stale       → 'reuse' (a rotated-out token replayed → revoke the family)
+ *  - jti matches        → 'rotated' with a fresh jti (TTL reset)
+ */
+export async function rotateSession(
+  familyId: string,
+  presentedJti: string,
+): Promise<RotateResult> {
+  const current = await redis.get(familyKey(familyId));
+  if (current === null) return { status: 'missing' };
+  if (current !== presentedJti) {
+    await redis.del(familyKey(familyId)); // theft signal — kill the whole family
+    return { status: 'reuse' };
+  }
+  const jti = randomUUID();
+  await redis.set(familyKey(familyId), jti, 'EX', TTL_SECONDS);
+  return { status: 'rotated', jti };
+}
+
+/** Revoke a session family (logout). */
+export async function revokeSession(familyId: string): Promise<void> {
+  await redis.del(familyKey(familyId));
+}

--- a/server/src/middlewares/utils/jwtVerify.ts
+++ b/server/src/middlewares/utils/jwtVerify.ts
@@ -7,6 +7,9 @@ type JwtPayload = {
   username: string;
   name: string;
   profilePic: string | null;
+  // Present on refresh tokens (stateful sessions); absent on access tokens.
+  familyId?: string;
+  jti?: string;
   iat: number;
   exp: number;
 };

--- a/server/src/test/authSession.test.ts
+++ b/server/src/test/authSession.test.ts
@@ -1,0 +1,72 @@
+import request from 'supertest';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { app } from '../app.js';
+import { resetDb } from './helpers.js';
+
+type CookieRes = { headers: Record<string, string | string[] | undefined> };
+
+// Pull the "refreshToken=..." pair out of a Set-Cookie header.
+function refreshCookie(res: CookieRes): string {
+  const setCookie = res.headers['set-cookie'] as string[] | undefined;
+  const cookie = setCookie?.find((c) => c.startsWith('refreshToken='));
+  return cookie ? cookie.split(';')[0] : '';
+}
+
+function signup(username: string) {
+  return request(app).post('/api/v1/auth/signup').send({
+    username,
+    email: `${username}@example.com`,
+    name: 'Session Tester',
+    password: 'Password123!',
+  });
+}
+
+const refresh = (cookie: string) =>
+  request(app).post('/api/v1/auth/refresh-token').set('Cookie', cookie);
+
+describe('refresh-token rotation (Redis sessions)', () => {
+  beforeAll(async () => {
+    await resetDb();
+  });
+
+  it('rotates the token and rejects the previous one (reuse detection)', async () => {
+    const created = await signup('rotator');
+    expect(created.status).toBe(201);
+    const first = refreshCookie(created);
+    expect(first).toMatch(/^refreshToken=/);
+
+    // First refresh rotates → new cookie, old one is now stale.
+    const r1 = await refresh(first);
+    expect(r1.status).toBe(200);
+    expect(r1.body).toHaveProperty('accessToken');
+    const second = refreshCookie(r1);
+    expect(second).not.toBe(first);
+
+    // The rotated-in token still works...
+    // ...but replaying the OLD token is reuse → 401 and the family is revoked.
+    const reuse = await refresh(first);
+    expect(reuse.status).toBe(401);
+
+    // Reuse revoked the whole family, so even the current token now fails.
+    const afterRevoke = await refresh(second);
+    expect(afterRevoke.status).toBe(401);
+  });
+
+  it('logout revokes the session (refresh afterward fails)', async () => {
+    const created = await signup('logouter');
+    const cookie = refreshCookie(created);
+
+    const out = await request(app)
+      .post('/api/v1/auth/logout')
+      .set('Cookie', cookie);
+    expect(out.status).toBe(204);
+
+    const after = await refresh(cookie);
+    expect(after.status).toBe(401);
+  });
+
+  it('rejects a missing/unknown refresh token', async () => {
+    expect((await request(app).post('/api/v1/auth/refresh-token')).status).toBe(401);
+  });
+});

--- a/server/src/utils/generateTokenAndSetCookie.ts
+++ b/server/src/utils/generateTokenAndSetCookie.ts
@@ -4,24 +4,25 @@ import jwt from 'jsonwebtoken';
 const ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET!;
 const REFRESH_TOKEN_SECRET = process.env.REFRESH_TOKEN_SECRET!;
 
-export function generateRefreshTokenAndSetCookie(
-  res: Response,
-  userId: number,
-  username: string,
-  name: string,
-  profilePic: string | null,
-) {
-  const token = jwt.sign(
-    { userId, username, name, profilePic },
-    REFRESH_TOKEN_SECRET,
-    {
-      expiresIn: '7d',
-    },
-  );
+const REFRESH_MAX_AGE_MS = 1000 * 60 * 60 * 24 * 7; // 7 days
+
+export type RefreshClaims = {
+  userId: number;
+  username: string;
+  name: string;
+  profilePic: string | null;
+  familyId: string; // session family (one login)
+  jti: string; // this specific token within the family
+};
+
+// Sign a refresh JWT (carrying the session family + jti) and set it as the
+// httpOnly cookie. Used on login/signup and on every rotation.
+export function issueRefreshToken(res: Response, claims: RefreshClaims) {
+  const token = jwt.sign(claims, REFRESH_TOKEN_SECRET, { expiresIn: '7d' });
 
   res.cookie('refreshToken', token, {
     httpOnly: true,
-    maxAge: 1000 * 60 * 60 * 24 * 7, // 7 days
+    maxAge: REFRESH_MAX_AGE_MS,
     sameSite: 'strict',
   });
 


### PR DESCRIPTION
## Why
Refresh tokens were stateless 7-day JWTs: a stolen one worked until expiry, and logout only cleared the cookie (no real revocation). This makes the refresh token stateful via a Redis session store.

## What
Each login starts a session "family"; the refresh JWT carries familyId + jti, and Redis stores the single jti currently valid for that family (`refresh:{familyId}`, TTL 7d). The token is gated by both JWT signature and the Redis check.

- **Rotation** — `/auth/refresh-token` (now POST) issues a new jti each use and invalidates the old one.
- **Reuse detection** — replaying a rotated-out jti revokes the whole family (OAuth rotation-with-reuse-detection BCP) — a theft signal forces re-login.
- **Revocation** — logout deletes the family; refresh afterward fails.
- **Fails closed** — any Redis error → no token issued (a down Redis can't bypass revocation), so Redis is added to the prod compose.
- Access tokens stay stateless (15 min). Client shares a single in-flight refresh so concurrent 401s don't trip reuse detection. Also fixed dead `jwt.*` instanceof checks (jwtVerify throws JWTError).

## Testing
34 server tests green, including new authSession tests (rotation, reuse detection + family revocation, logout revocation). Manually verified e2e: login creates the Redis session key, refresh rotates (200), reuse/logout revoke, and a valid token with Redis stopped returns 500 (fail closed — never issues a token).

## Deploy note
`server/.prod.env` must add `REDIS_URL=redis://redis:6379` before deploying (the compose now runs a redis service the server depends on).