### PR TITLE
Log out everywhere (per-user session revocation)

### DIFF
--- a/docs/auth-sessions.md
+++ b/docs/auth-sessions.md
@@ -14,6 +14,9 @@ POST /auth/refresh-token (cookie) ──> verify JWT, then check Redis:
    jti == stored jti       → rotate: new jti, reset TTL, set new cookie, new access token
 
 POST /auth/logout (cookie) ──> DEL refresh:{familyId}, clear cookie
+
+POST /auth/logout-all (access token) ──> DEL every family in user:{id}:families,
+   DEL the set, clear cookie  ("log out everywhere")
 ```
 
 ## Why
@@ -37,8 +40,24 @@ A stateless refresh JWT can't be revoked — logout only clears the cookie, so a
   alone proves authenticity, Redis proves it hasn't been rotated out or revoked.
 
 Files: `server/src/features/auth/session.ts` (Redis helpers: `createSession`,
-`rotateSession`, `revokeSession`), `authController.ts` (login/signup/refresh/logout),
+`rotateSession`, `revokeSession`, `revokeAllSessions`), `authController.ts`
+(login/signup/refresh/logout/logoutAll), `authRouter.ts` (routes),
 `utils/generateTokenAndSetCookie.ts` (`issueRefreshToken`).
+
+## Log out everywhere
+
+A login can spawn many sessions (phone, laptop, …), each its own family. To revoke
+them all at once we keep a per-user index: a Redis **set** `user:{id}:families`
+holding that user's family ids. `createSession` `SADD`s the new family (and resets
+the set's 7-day TTL); `revokeAllSessions(userId)` reads the set, `DEL`s every
+`refresh:{familyId}` in it, then drops the set. `POST /auth/logout-all` is
+authenticated by the **access token** (it identifies the user without a cookie) and
+also clears the current cookie, since "everywhere" includes this device.
+
+The set is a **best-effort index, not truth**: a family can expire or be revoked
+while its id lingers in the set, but revocation just `DEL`s by key (a no-op if it's
+already gone), and the set's TTL self-bounds it to roughly the last 7 days of
+sessions. So stale members are harmless and never cause a wrong revocation.
 
 ## Fail closed
 
@@ -60,11 +79,14 @@ the immediately-previous jti is an alternative; not implemented.)
 
 `server/src/test/authSession.test.ts`: refresh rotates (old token rejected); replaying
 a rotated-out token → 401 **and** the family is revoked (the current token then also
-fails); logout → subsequent refresh 401; missing token → 401.
+fails); logout → subsequent refresh 401; missing token → 401; **log out everywhere**
+across two sessions → `{ revokedSessions: 2 }` and both devices' refreshes 401;
+`/auth/logout-all` without an access token → 401.
 
 ## Out of scope / next
 
-- **Per-user session list / "log out everywhere"** — would need an index of a user's
-  families (e.g. a Redis set keyed by userId). Easy extension on this model.
-- **Access-token denylist** — access tokens stay stateless, so a compromised one is
-  valid until it expires (15 min); a denylist would close that window if needed.
+- **Access-token denylist** — access tokens stay stateless, so a compromised one (or
+  one held by a device after "log out everywhere") is valid until it expires (≤15 min);
+  a Redis denylist checked in `protectRoute` would close that residual window.
+- **Per-user session *list* UI** — the index now exists; surfacing active sessions
+  ("Chrome on macOS · last active 2h ago") would need per-family device metadata.

--- a/server/src/features/auth/authController.ts
+++ b/server/src/features/auth/authController.ts
@@ -10,7 +10,12 @@ import {
   generateAccessToken,
   issueRefreshToken,
 } from '../../utils/generateTokenAndSetCookie.js';
-import { createSession, revokeSession, rotateSession } from './session.js';
+import {
+  createSession,
+  revokeAllSessions,
+  revokeSession,
+  rotateSession,
+} from './session.js';
 import { checkPassword } from './utils/checkPassword.js';
 
 type AuthUser = {
@@ -22,7 +27,7 @@ type AuthUser = {
 
 // Start a session, set the rotating refresh cookie, and return the auth payload.
 async function issueSession(res: Response, user: AuthUser) {
-  const { familyId, jti } = await createSession();
+  const { familyId, jti } = await createSession(user.id);
   issueRefreshToken(res, {
     userId: user.id,
     username: user.username,
@@ -116,11 +121,13 @@ export async function logout(req: Request, res: Response) {
         : undefined;
     if (token) {
       try {
-        const { familyId } = await jwtVerify(
+        const { userId, familyId } = await jwtVerify(
           token,
           process.env.REFRESH_TOKEN_SECRET!,
         );
-        if (familyId) await revokeSession(familyId);
+        if (familyId && typeof userId === 'number') {
+          await revokeSession(userId, familyId);
+        }
       } catch {
         // ignore — clear the cookie regardless
       }
@@ -129,6 +136,22 @@ export async function logout(req: Request, res: Response) {
   } catch (error) {
     res.status(500).json({ message: 'An unknown error occurred.' });
     console.error('Error in logout: ', error);
+  }
+}
+
+// "Log out everywhere": revoke every session family for the authenticated user,
+// invalidating all their refresh tokens (including this device's — so the cookie
+// is cleared too). Identity comes from the access token (protectRoute), and this
+// fails CLOSED: if Redis revocation throws, we 500 rather than report success.
+// Note: stateless access tokens already issued stay valid until they expire
+// (≤15m); revoking those is the separate access-token-denylist work.
+export async function logoutAll(req: Request, res: Response) {
+  try {
+    const revokedSessions = await revokeAllSessions(req.user!.id);
+    res.clearCookie('refreshToken').status(200).json({ revokedSessions });
+  } catch (error) {
+    res.status(500).json({ message: 'An unknown error occurred.' });
+    console.error('Error in logoutAll: ', error);
   }
 }
 

--- a/server/src/features/auth/authRouter.ts
+++ b/server/src/features/auth/authRouter.ts
@@ -1,11 +1,20 @@
 import { Router } from 'express';
 
-import { login, logout, refreshAccessToken, signup } from './authController.js';
+import { protectRoute } from '../../middlewares/protectRoute.js';
+import {
+  login,
+  logout,
+  logoutAll,
+  refreshAccessToken,
+  signup,
+} from './authController.js';
 
 export const authRouter: Router = Router();
 
 authRouter.post('/signup', signup);
 authRouter.post('/login', login);
 authRouter.post('/logout', logout);
+// Log out everywhere — authenticated by the access token, revokes all sessions.
+authRouter.post('/logout-all', protectRoute, logoutAll);
 // POST: rotation mutates server state (issues a new refresh token).
 authRouter.post('/refresh-token', refreshAccessToken);

--- a/server/src/features/auth/session.ts
+++ b/server/src/features/auth/session.ts
@@ -14,6 +14,12 @@ import { redis } from '../../redis.js';
 const TTL_SECONDS = 7 * 24 * 60 * 60; // matches the 7-day refresh cookie
 
 export const familyKey = (familyId: string) => `refresh:${familyId}`;
+/** Set of a user's active session families, so they can all be revoked at once
+ *  ("log out everywhere"). Stale members are harmless — a family key may expire
+ *  or be revoked while its id lingers here, but revoking just DELs by key (a
+ *  no-op if already gone). The set's TTL is refreshed on each new session, so it
+ *  self-bounds to roughly the last 7 days of sessions. */
+export const userFamiliesKey = (userId: number) => `user:${userId}:families`;
 
 export type SessionToken = { familyId: string; jti: string };
 
@@ -22,11 +28,16 @@ export type RotateResult =
   | { status: 'reuse' }
   | { status: 'missing' };
 
-/** Start a new session family with its first token. */
-export async function createSession(): Promise<SessionToken> {
+/** Start a new session family for a user with its first token. */
+export async function createSession(userId: number): Promise<SessionToken> {
   const familyId = randomUUID();
   const jti = randomUUID();
-  await redis.set(familyKey(familyId), jti, 'EX', TTL_SECONDS);
+  await redis
+    .multi()
+    .set(familyKey(familyId), jti, 'EX', TTL_SECONDS)
+    .sadd(userFamiliesKey(userId), familyId)
+    .expire(userFamiliesKey(userId), TTL_SECONDS)
+    .exec();
   return { familyId, jti };
 }
 
@@ -51,7 +62,28 @@ export async function rotateSession(
   return { status: 'rotated', jti };
 }
 
-/** Revoke a session family (logout). */
-export async function revokeSession(familyId: string): Promise<void> {
-  await redis.del(familyKey(familyId));
+/** Revoke a single session family (logout on this device). */
+export async function revokeSession(
+  userId: number,
+  familyId: string,
+): Promise<void> {
+  await redis
+    .multi()
+    .del(familyKey(familyId))
+    .srem(userFamiliesKey(userId), familyId)
+    .exec();
+}
+
+/**
+ * Revoke every session family for a user ("log out everywhere"). Deletes all
+ * family keys in the user's set, then drops the set. Returns how many families
+ * were revoked. Idempotent: an empty set revokes nothing and returns 0.
+ */
+export async function revokeAllSessions(userId: number): Promise<number> {
+  const familyIds = await redis.smembers(userFamiliesKey(userId));
+  const pipeline = redis.multi();
+  for (const familyId of familyIds) pipeline.del(familyKey(familyId));
+  pipeline.del(userFamiliesKey(userId));
+  await pipeline.exec();
+  return familyIds.length;
 }

--- a/server/src/test/authSession.test.ts
+++ b/server/src/test/authSession.test.ts
@@ -22,6 +22,11 @@ function signup(username: string) {
   });
 }
 
+const login = (username: string) =>
+  request(app)
+    .post('/api/v1/auth/login')
+    .send({ email: `${username}@example.com`, password: 'Password123!' });
+
 const refresh = (cookie: string) =>
   request(app).post('/api/v1/auth/refresh-token').set('Cookie', cookie);
 
@@ -68,5 +73,32 @@ describe('refresh-token rotation (Redis sessions)', () => {
 
   it('rejects a missing/unknown refresh token', async () => {
     expect((await request(app).post('/api/v1/auth/refresh-token')).status).toBe(401);
+  });
+
+  it('logs out everywhere: revokes every session for the user', async () => {
+    // Two devices: signup starts session A, a second login starts session B.
+    const created = await signup('omni');
+    const cookieA = refreshCookie(created);
+    const accessToken = (created.body as { accessToken: string }).accessToken;
+
+    const second = await login('omni');
+    const cookieB = refreshCookie(second);
+    expect(cookieB).not.toBe(cookieA);
+
+    // Both sessions are valid beforehand (use a clone so we don't rotate the
+    // ones we assert on; instead just confirm the endpoint reports two families).
+    const out = await request(app)
+      .post('/api/v1/auth/logout-all')
+      .set('Authorization', `Bearer ${accessToken}`);
+    expect(out.status).toBe(200);
+    expect((out.body as { revokedSessions: number }).revokedSessions).toBe(2);
+
+    // Every session is now dead — neither device can refresh.
+    expect((await refresh(cookieA)).status).toBe(401);
+    expect((await refresh(cookieB)).status).toBe(401);
+  });
+
+  it('requires authentication to log out everywhere', async () => {
+    expect((await request(app).post('/api/v1/auth/logout-all')).status).toBe(401);
   });
 });


### PR DESCRIPTION
## What

Adds "log out everywhere" — revoke every session for a user at once — building on the stateful refresh-token sessions from #25. Backend + endpoint only; no UI in this PR (see Notes).

```
login/signup ──> createSession(userId): SET refresh:{familyId}=jti (TTL 7d)
                 + SADD user:{userId}:families (set TTL 7d)

POST /auth/logout-all (access token) ──> revokeAllSessions(userId):
   SMEMBERS user:{userId}:families → DEL every refresh:{familyId} → DEL the set
   clear cookie, return { revokedSessions: n }
```

## How

- **Per-user index**: a Redis set `user:{userId}:families` tracks a user's active session families. `createSession` now takes the `userId` and `SADD`s the new family (resetting the set's 7-day TTL); `revokeAllSessions` reads the set, deletes every `refresh:{familyId}`, then drops the set.
- **Endpoint**: `POST /auth/logout-all`, authenticated by the **access token** (`protectRoute`, so it identifies the user without a refresh cookie), revokes all families including this device's, clears the current cookie, and returns the count. **Fails closed** — a Redis error 500s rather than reporting a false success.
- **The set is a best-effort index, not truth**: a family can expire or be revoked while its id lingers in the set, but revocation only `DEL`s by key (a no-op if already gone), so stale members are harmless and never cause a wrong revocation; the set's TTL self-bounds it to roughly the last 7 days of sessions. (This is why the hot refresh/rotation path deliberately doesn't `SREM` — not worth the coupling when stale entries are provably safe.)

## Honest limitation

Access tokens stay **stateless** (≤15-min JWT, validated by signature in `protectRoute`), so "log out everywhere" revokes *refresh* families but an already-issued access token remains valid until it expires — a bounded (≤15 min) revocation gap. That's the deliberate stateless-JWT trade-off (cheap local auth checks vs instant revocability); closing it is the follow-up **access-token denylist** (a Redis set checked in `protectRoute`).

## Verified

- Integration (`authSession.test.ts`, real Redis): two sessions for one user → `POST /logout-all` → `{ revokedSessions: 2 }`, and both devices' subsequent refreshes 401; `/logout-all` without an access token → 401.
- Live stack (redis-cli): `user:{id}:families` holds the family UUIDs with a ~7-day TTL, and both the set and all family keys are gone after `logout-all`.
- 49 server tests green, lint + typecheck clean.

## Notes

- **No UI in this PR.** A menu button was prototyped and removed: "log out everywhere" is a security-settings action with no good home until there's a Security/Sessions settings page (wedging a second "Logout" into the account menu is confusing). The endpoint ships and is usable; the UI is deferred to that future page (which would also host an active-sessions list, now that the per-user index exists).
- No schema/migration/dependency changes; reuses the existing Redis (already in the prod compose from the refresh-token work).