### PR TITLE
Fix logout-on-reload (refresh-token is POST, not GET)

### DIFF
--- a/client/src/hooks/useAccessToken.ts
+++ b/client/src/hooks/useAccessToken.ts
@@ -1,34 +1,26 @@
-import { AuthResponse, axiosInstance } from '@/api/axiosConfig.ts';
+import { refreshAccessToken } from '@/utils/refreshAccessToken.ts';
 import { useAuthStore } from '@stores/authStore.ts';
 import { useQuery } from '@tanstack/react-query';
 
 const MINUTE = 1000 * 60;
 
+// Restores the session on mount and proactively refreshes the access token on an
+// interval. It goes through the shared single-flight `refreshAccessToken` rather
+// than calling the endpoint directly, for two reasons:
+//   1. refresh-token is POST (it rotates server state). Calling it as GET 404s,
+//      which would clear the token and log the user out on every reload.
+//   2. Concurrent refreshes (this hook + the axios 401 interceptor) would present
+//      the same rotated-out token and trip reuse detection -> forced logout.
+//      Single-flight collapses them into one in-flight request.
 export function useAccessToken() {
-  const setAccessToken = useAuthStore((state) => state.setAccessToken);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
-  // setAccessToken is a stable store setter used as a side-effect sink, not a
-  // cache input, so it intentionally stays out of the query key.
-  // eslint-disable-next-line @tanstack/query/exhaustive-deps
   const { isPending, isError } = useQuery({
     queryKey: ['accessToken'],
     queryFn: async () => {
-      const response = await axiosInstance.get<AuthResponse>(
-        '/auth/refresh-token',
-      );
-      const { accessToken, userId, username, name, profilePic } = response.data;
-
-      if (accessToken) {
-        setAccessToken(accessToken, {
-          userId,
-          username,
-          name,
-          profilePic,
-        });
-      }
-
-      return response.data;
+      const token = await refreshAccessToken();
+      if (!token) throw new Error('Not authenticated');
+      return token;
     },
     retry: false,
     refetchInterval: () => (isAuthenticated ? 13 * MINUTE : false),


### PR DESCRIPTION
useAccessToken restored the session on mount via GET /auth/refresh-token, but the route is POST (it rotates the refresh token), so it 404'd, cleared the access token, and logged the user out on every reload. Route it through the shared single-flight refreshAccessToken (POST) instead — which also prevents this hook from racing the axios 401 interceptor's refresh (two concurrent refreshes present the same rotated-out token and trip reuse detection). Verified: login → reload keeps the session (token is in-memory only, so a surviving session proves the refresh succeeded).