### PR TITLE
docs+test: notification design doc and load-test harness

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -86,6 +86,51 @@ the global OR entirely; candidate sources are bounded/indexed (~1 ms social-proo
 ~0.4 ms recent-popular; followed authors O(1) from the fan-out feed when warm, or a
 ~168 ms backward-PK-scan DB fallback). See `docs/for-you.md`.
 
+## Real-time notification fan-out (WebSocket + Redis pub/sub)
+
+How far the notification path (`docs/notifications.md`) scales on a single API
+instance, and what delivery latency looks like under load. Captured with the
+committed harness: `CONN=<n> ROUNDS=5 pnpm --filter server loadtest:notifications`.
+
+### Method
+
+- One Node API instance + one Redis, local. The harness opens `CONN` concurrent
+  authenticated WebSocket connections, then each round **publishes one message to
+  every connection's channel at once** and records `receive − publish` (wall-clock,
+  ms) per delivery. Publishing direct to Redis isolates the ws + pub/sub transport
+  from the DB write.
+- This is a **synchronised broadcast** — all `CONN` messages fan out in the same
+  instant — so it's the worst case for a single-threaded event loop, not a
+  steady-state trickle. Round 1 is dropped as warm-up.
+
+### Results
+
+| Concurrent connections | Delivery | Fan-out p50 | Fan-out p99 |
+| --- | --- | --- | --- |
+| 1,000  | 100% | 11 ms  | 16 ms  |
+| 5,000  | 100% | 45 ms  | 54 ms  |
+| 10,000 | 100% | 69 ms  | 94 ms  |
+| 16,324 | 100% | 101 ms | 171 ms |
+
+Connection establishment held ~4,000 conn/s up to 10k. **Zero dropped messages**
+at every level.
+
+### Reading the numbers
+
+- **A single Node instance holds 10k live connections and fans a simultaneous
+  broadcast out to all of them with p99 < 100 ms, 100% delivery.** Latency scales
+  roughly linearly because every round pushes `CONN` sends through one event loop in
+  one burst; in production, notifications arrive spread over time, not all at once,
+  so steady-state per-event latency is far below these synchronised-broadcast figures.
+- **The ~16k ceiling is the test client, not the server.** Asking for 20k, only
+  16,324 connected — that's the loopback **ephemeral-port range** of a single client
+  process (macOS ~49152–65535). The server never errored or dropped; horizontal
+  client spread (or more instances) would go further. The honest single-instance
+  number is therefore "≥10k comfortable; client-bound past ~16k."
+- **Caveats:** localhost loopback (no real network RTT), single API instance, single
+  test client, ms-resolution wall clock. Useful for the *shape* (linear fan-out cost,
+  100% delivery, where one instance saturates), not as an absolute production SLA.
+
 ## What this doesn't fix (next steps)
 
 - **Search** still uses `ILIKE '%q%'` (`searchPosts`/`searchUsers`), which can't

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,57 @@
+# Notifications (WebSocket + Redis pub/sub fan-out)
+
+A like, follow, or reply notifies the recipient in real time. Unlike trending, this feature
+does **not** need a stream processor: there's no windowing, no replay, no out-of-order
+aggregation — just "write a row, push it to whoever's connected." So the implementation is the
+plain one: write the `Notification` row in the **same transaction** as the source action, then
+fan it out over a WebSocket using **Redis pub/sub** to reach the connection wherever it lives.
+
+```
+like / follow / reply (one Prisma $transaction)
+      │  source write  +  createNotification(tx, …)   ← atomic; skips self-notify
+      ▼  COMMIT
+  publishNotification ─▶ redis PUBLISH notifications:user:{recipientId}   ← best-effort
+      │
+      ▼  (every API instance) redis PSUBSCRIBE notifications:user:*
+  wsHub: Map<userId, Set<ws>> ─▶ send() to that user's local sockets
+      │
+  browser: useNotificationSocket (one socket/session) ─▶ toast + invalidate React Query
+      ▼
+  GET /api/v1/notifications        (keyset list, Activity page)
+  GET /api/v1/notifications/unread-count   (nav badge)
+```
+
+- **Truth**: `Notification` rows in Postgres. **Transport**: Redis pub/sub (ephemeral — not a store). The row is durable the instant the source action commits; the WebSocket is just live delivery on top.
+
+## Why this shape
+
+- **Atomic with the source action.** `createNotification` takes the caller's `Prisma.TransactionClient`, so the notification row and the like/follow/reply commit or roll back together — a notification can't exist for an action that didn't happen, and vice versa.
+- **Emit on the positive action only.** Notifications are created in the like-create / follow-create / reply branches, never on the un-action, so toggling like→unlike→like can't spam the recipient. Self-notify (`actorId === recipientId`) returns null and is skipped.
+- **Publish is best-effort.** The row is already durably stored and will surface on the next Activity fetch, so a Redis hiccup must never fail the user's action — a like shouldn't 500 because live fan-out was momentarily down. `publishNotification` catches and logs; it never propagates.
+- **Why Redis pub/sub, not Kafka.** A broker buys decoupling, replay, and buffering. Live notification delivery wants none of those: a message the recipient wasn't connected for is *not* replayed (they read it from the DB list instead), there's one logical consumer (the API), and no burst pressure to buffer. Pub/sub's fire-and-forget, at-most-once delivery is exactly the semantics here — adding Kafka would be cost (a stateful broker + a replication slot to babysit) with no benefit. Contrast trending, which genuinely needs windowed stream processing; see `docs/trending.md`.
+- **Why pub/sub at all (vs. an in-process map).** The `Map<userId, Set<ws>>` only knows the sockets on *this* process. With more than one API instance behind a load balancer, the actor's request and the recipient's socket can land on different instances. `PUBLISH`/`PSUBSCRIBE` decouples "who emitted" from "who holds the socket": every instance subscribes to `notifications:user:*` and delivers to whatever local sockets it has, so it works horizontally with zero sticky-session requirement.
+
+## The WebSocket hub (`server/src/realtime/wsHub.ts`)
+
+- `WebSocketServer({ noServer: true })` shares the existing HTTP server via its `upgrade` event — no second port, so it rides the same TLS/reverse-proxy in prod and the Vite `/api` proxy (`ws: true`) in dev.
+- **Auth on the handshake.** The browser `WebSocket` API can't set an `Authorization` header, so the short-lived access token is passed as `?token=…` and verified with the same `jwtVerify` + `ACCESS_TOKEN_SECRET` as REST. A bad/missing token destroys the socket before the upgrade completes (no half-open authenticated connection).
+- **Subscriber connection is separate.** A Redis connection in subscriber mode can't issue normal commands, so the hub `duplicate()`s the shared command client for its `PSUBSCRIBE`. One subscription per process; each `pmessage` is routed by parsing the userId out of the channel and looking it up in the local map.
+- **Heartbeat.** `ws` doesn't surface liveness, so each socket is tagged and pinged every 30s; any that didn't pong since the last tick is terminated. This reclaims half-open connections (laptop sleep, dropped Wi-Fi) that TCP alone wouldn't notice for a long time.
+
+## Client (`client/src/hooks/useNotificationSocket.ts`)
+
+- One same-origin socket for the whole authenticated session, mounted once in `AppLayout`. On each frame it shows a toast and **invalidates** the notification queries — the socket is the "something changed" signal; the REST hooks (`useNotifications`, `useUnreadCount`) own the data, so the list and the unread badge stay a single source of truth.
+- Reconnects with exponential backoff (1s → 30s cap), resetting on a healthy open; tears down cleanly on logout / token change so a stale token's socket never lingers.
+- The wire payload is produced by the server's `serializeNotification` and is byte-identical to a REST list row (`notificationInclude` is shared), so the client renders a pushed notification and a fetched one with the same code.
+
+## Verified
+
+End-to-end on the live stack (server + Vite client + Redis): logged in as one user with the Activity socket open, triggered a follow then a like from a second account. The follow and like arrived **live without a reload** — the nav unread badge incremented, a toast fired, and the Activity list showed the new rows newest-first (with the liked post's text snippet). Viewing the page marked all read and cleared the badge. A standalone Node harness also confirms the raw path: a follow produces a WebSocket frame with the hydrated actor payload, the row persists in `GET /notifications`, and `unread-count` reflects it. All 49 server tests stay green (the best-effort publish is what keeps a Redis-down test from 500-ing the like/follow path).
+
+## Out of scope / next
+
+- **No prod broker, by decision.** Redis (already in prod for the like-counter view and refresh-token sessions) is the only new prod dependency — no Kafka/Flink on this path. See the prod-realtime rationale: a broker goes on the critical path only where replay/decoupling/windowing is actually needed.
+- **Dedup tradeoff.** No DB unique constraint on `Notification`; emitting only on the positive action handles the common toggle case, but a like→unlike→like still produces a second row. Acceptable for a single-user portfolio app; a partial unique index or upsert is the refinement.
+- **At-most-once live delivery.** A notification published while the recipient is offline is not queued for the socket — it's simply read from the durable list on next load. Presence/typing indicators and read receipts (per-notification, beyond mark-all-on-view) are deliberately not built.
+- **Messages / DMs** are a separate, larger feature (conversation + message models) and intentionally not part of this phase, though they'd reuse this same hub + pub/sub transport.
+- **Migration note.** Prisma can't model the generated `textsearch` tsvector column (`Unsupported`), so its schema diff spuriously emits `ALTER TABLE "Post" … "textsearch" DROP DEFAULT` (rejected by Postgres, error 42601). That one bogus line is removed from this feature's migration; the column, its generation expression, and the search GIN index are untouched.

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
     "consume:likes": "tsx --env-file=.env src/consumers/likeCounter.ts",
     "feed:reconcile": "tsx --env-file=.env src/scripts/reconcileFeeds.ts",
     "consume:feed": "tsx --env-file=.env src/consumers/timelineFanout.ts",
+    "loadtest:notifications": "tsx --env-file=.env src/scripts/loadtestNotifications.ts",
     "search:reconcile": "tsx --env-file=.env src/scripts/reconcileSearch.ts",
     "consume:search": "tsx --env-file=.env src/consumers/searchIndexer.ts",
     "test": "vitest run",

--- a/server/src/scripts/loadtestNotifications.ts
+++ b/server/src/scripts/loadtestNotifications.ts
@@ -1,0 +1,146 @@
+import Redis from 'ioredis';
+import jwt from 'jsonwebtoken';
+import { WebSocket } from 'ws';
+
+import { prisma } from '../db/index.js';
+import { notificationChannel } from '../features/notification/notificationService.js';
+
+// Load test for the notification fan-out path. Opens CONN concurrent
+// authenticated WebSocket connections against a running server, then publishes
+// one message to each connection's Redis channel and measures the publish→receive
+// delivery latency (p50/p99). This isolates the thing we scale — the WebSocket
+// hub + Redis pub/sub fan-out — from the DB write, so the number reflects
+// transport behaviour under load on a single API instance.
+//
+// Run against a live server (see package.json `loadtest:notifications`):
+//   CONN=5000 ROUNDS=5 pnpm --filter server loadtest:notifications
+const CONN = Number(process.env.CONN ?? process.argv[2] ?? 1000);
+const ROUNDS = Number(process.env.ROUNDS ?? 5);
+const HOST = process.env.WS_HOST ?? 'localhost:3000';
+const OPEN_BATCH = 500; // connections opened per batch, to avoid a thundering herd
+const DELIVER_TIMEOUT_MS = 10_000;
+const SECRET = process.env.ACCESS_TOKEN_SECRET;
+
+type TaggedWS = WebSocket & { userId: number };
+
+function percentile(sortedAsc: number[], p: number): number {
+  if (sortedAsc.length === 0) return NaN;
+  const idx = Math.min(
+    sortedAsc.length - 1,
+    Math.floor((p / 100) * sortedAsc.length),
+  );
+  return sortedAsc[idx];
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function main() {
+  if (!SECRET) throw new Error('ACCESS_TOKEN_SECRET not set (run with --env-file=.env)');
+
+  // Real, existing user ids so the hub's user-exists check passes.
+  const users = await prisma.user.findMany({
+    select: { id: true },
+    orderBy: { id: 'asc' },
+    take: CONN,
+  });
+  const ids = users.map((u) => u.id);
+  console.log(`Target: ${ids.length} connections to ws://${HOST}, ${ROUNDS} rounds`);
+
+  // Per-round latency collector; the message handler computes recv − publish.
+  let latencies: number[] = [];
+  const sockets: TaggedWS[] = [];
+
+  const openOne = (id: number) =>
+    new Promise<void>((resolve) => {
+      const token = jwt.sign({ userId: id }, SECRET, { expiresIn: '15m' });
+      const ws = new WebSocket(
+        `ws://${HOST}/api/v1/ws?token=${token}`,
+      ) as TaggedWS;
+      ws.userId = id;
+      ws.on('open', () => resolve());
+      ws.on('error', () => resolve()); // count established below; failures just don't open
+      ws.on('message', (data: Buffer) => {
+        try {
+          const msg = JSON.parse(data.toString()) as { __t?: number };
+          if (msg.__t) latencies.push(Date.now() - msg.__t);
+        } catch {
+          /* ignore */
+        }
+      });
+      sockets.push(ws);
+    });
+
+  // Open in batches and time it.
+  const openStart = Date.now();
+  for (let i = 0; i < ids.length; i += OPEN_BATCH) {
+    await Promise.all(ids.slice(i, i + OPEN_BATCH).map(openOne));
+  }
+  const established = sockets.filter((s) => s.readyState === WebSocket.OPEN).length;
+  const openMs = Date.now() - openStart;
+  console.log(
+    `Established ${established}/${ids.length} connections in ${openMs} ms ` +
+      `(${Math.round((established / openMs) * 1000)} conn/s)`,
+  );
+
+  // Dedicated publisher (mirrors what the API does on a like/follow/reply).
+  const pub = new Redis(process.env.REDIS_URL ?? 'redis://localhost:6379');
+
+  const openIds = sockets
+    .filter((s) => s.readyState === WebSocket.OPEN)
+    .map((s) => s.userId);
+
+  const roundStats: { delivered: number; p50: number; p99: number; max: number }[] = [];
+  for (let round = 1; round <= ROUNDS; round++) {
+    latencies = [];
+    // One message per connected user, each stamped at its own publish moment.
+    const pipeline = pub.pipeline();
+    for (const id of openIds) {
+      pipeline.publish(
+        notificationChannel(id),
+        JSON.stringify({ __t: Date.now(), type: 'LIKE' }),
+      );
+    }
+    await pipeline.exec();
+
+    // Wait until everything lands (or the timeout).
+    const deadline = Date.now() + DELIVER_TIMEOUT_MS;
+    while (latencies.length < openIds.length && Date.now() < deadline) {
+      await sleep(20);
+    }
+
+    const sorted = [...latencies].sort((a, b) => a - b);
+    const stat = {
+      delivered: sorted.length,
+      p50: percentile(sorted, 50),
+      p99: percentile(sorted, 99),
+      max: sorted.length ? sorted[sorted.length - 1] : NaN,
+    };
+    roundStats.push(stat);
+    console.log(
+      `round ${round}: delivered ${stat.delivered}/${openIds.length}  ` +
+        `p50 ${stat.p50}ms  p99 ${stat.p99}ms  max ${stat.max}ms`,
+    );
+    await sleep(500);
+  }
+
+  // Aggregate across rounds (drop round 1 as warm-up if more than one round).
+  const measured = roundStats.length > 1 ? roundStats.slice(1) : roundStats;
+  const avg = (xs: number[]) => xs.reduce((a, b) => a + b, 0) / xs.length;
+  console.log('\n=== summary (excl. warm-up round) ===');
+  console.log(`connections established : ${established}`);
+  console.log(`open throughput         : ${Math.round((established / openMs) * 1000)} conn/s`);
+  console.log(`delivery ratio          : ${(avg(measured.map((r) => r.delivered)) / openIds.length * 100).toFixed(2)}%`);
+  console.log(`fan-out latency p50      : ${avg(measured.map((r) => r.p50)).toFixed(1)} ms`);
+  console.log(`fan-out latency p99      : ${avg(measured.map((r) => r.p99)).toFixed(1)} ms`);
+  console.log(`fan-out latency max      : ${Math.max(...measured.map((r) => r.max))} ms`);
+
+  for (const s of sockets) s.terminate();
+  pub.disconnect();
+  await prisma.$disconnect();
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Follow-up to the notifications feature (PR #30), which merged the code but not its docs or load test. Adds the subsystem design doc, a WebSocket load-test harness, and the measured fan-out numbers. No runtime code changes.

- docs/notifications.md — tradeoff-first writeup: ws + Redis pub/sub fan-out, why pub/sub over Kafka (no replay/buffering/windowing needed), why pub/sub over an in-process map (horizontal fan-out with no sticky sessions), handshake auth via query token, heartbeat, and best-effort publish.
- server/src/scripts/loadtestNotifications.ts (+ `pnpm loadtest:notifications`) — opens N concurrent authed WebSocket connections, publishes one stamped message per connection's Redis channel, and measures publish→receive fan-out latency (p50/p99) + delivery ratio + connection-open throughput. Isolates the transport from the DB write.
- docs/benchmarks.md — results: 100% delivery at 1k/5k/10k/16k concurrent connections, p99 fan-out latency < 100 ms at 10k under a synchronised broadcast (worst case). Notes the ~16k cap as the test client's loopback ephemeral-port limit, not a server ceiling, with method + caveats.