### PR TITLE
feat(server): implement S3 storage backend

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -11,9 +11,9 @@ client file picker ──> POST /api/v1/upload (multipart, protectRoute)
                        storage.save(buffer, contentType)      ← the seam
                               │
               ┌───────────────┴────────────────┐
-        DiskStorage                        S3Storage (stub)
+        DiskStorage                        S3Storage
    writes UPLOAD_DIR/<uuid>.<ext>     PutObject to a bucket
-   returns /api/v1/media/<uuid>.<ext>  returns the CDN URL
+   returns /api/v1/media/<uuid>.<ext>  returns the CDN (or bucket) URL
                               │
         GET /api/v1/media/<file> ──> express.static(UPLOAD_DIR)   (disk only)
 ```
@@ -26,10 +26,11 @@ client file picker ──> POST /api/v1/upload (multipart, protectRoute)
   MIME → extension map.
 - **`diskStorage.ts`** — writes bytes to a directory, serves them back as relative
   URLs under the API prefix.
-- **`s3Storage.ts`** — a documented stub. Turning it on is self-contained: implement
-  the two methods, add `@aws-sdk/client-s3`, set `STORAGE_DRIVER=s3`. Nothing in the
-  controllers, the client, or the seed knows which backend ran — they only see the
-  returned `url`.
+- **`s3Storage.ts`** — the S3 backend (also works against S3-compatible stores like
+  Cloudflare R2 or MinIO via `S3_ENDPOINT`). Turning it on is self-contained: set
+  `STORAGE_DRIVER=s3` and `S3_BUCKET`. The AWS SDK is imported lazily, so a disk-only
+  deploy never loads it. Nothing in the controllers, the client, or the seed knows
+  which backend ran — they only see the returned `url`.
 - **`index.ts`** — the factory that picks a backend from `STORAGE_DRIVER` (default
   `disk`) plus the path/URL config.
 
@@ -43,7 +44,16 @@ S3 the stored URL just becomes the bucket/CDN URL and this static route goes idl
 | Env | Default | Notes |
 | --- | --- | --- |
 | `STORAGE_DRIVER` | `disk` | `disk` or `s3` |
-| `UPLOAD_DIR` | `./uploads` (cwd) | Disk-backend write dir. Absolute in prod. |
+| `UPLOAD_DIR` | `./uploads` (cwd) | Disk backend: write dir. Absolute in prod. |
+| `S3_BUCKET` | — | S3 backend: target bucket (required when `s3`). |
+| `AWS_REGION` | `us-east-1` | S3 backend: region (and URL construction). |
+| `S3_CDN_URL` | — | Public CDN base in front of the bucket (e.g. CloudFront). Falls back to the bucket URL. |
+| `S3_KEY_PREFIX` | — | Optional "folder" within the bucket, e.g. `media`. |
+| `S3_ENDPOINT` | — | Custom endpoint for S3-compatible stores (R2, MinIO). |
+| `S3_FORCE_PATH_STYLE` | `false` | `true` for stores that need path-style URLs (MinIO). |
+
+Credentials come from the standard AWS chain (env vars, shared config, or the
+instance/task IAM role) — they are never read or stored by the app directly.
 
 The upload endpoint accepts up to 4 image files (`jpeg/png/webp/gif/svg`), 5 MB each.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
 
   server:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.658.1
+        version: 3.1064.0
       '@elastic/elasticsearch':
         specifier: ^8.19.1
         version: 8.19.1
@@ -255,6 +258,109 @@ importers:
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.22.4))
 
 packages:
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/checksums@3.1000.3':
+    resolution: {integrity: sha512-vkPd3NMJf6Gw4QjBBdiUdu2uo4P0HfHrx5+1hqjDYZhZAF4HWkMHXoQtxHQmDi/LyysUgTU5uNhcZLCkpF9LKg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1064.0':
+    resolution: {integrity: sha512-6OQhE4Qpt94oTw7ruBHE2E6/PS57alsCSdemMf4c3gBSUM0emoXRRykYffFSL56oluL49AZh/DLWRnQafynbLg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.19':
+    resolution: {integrity: sha512-SMNfLCU/41xxfFaC5Slwy8V/f1FRhakvyeeMeDeIxqNF0DzhDlXsXnJDELJYke1EtnJbfzfilW7tvulGfxMY6A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.45':
+    resolution: {integrity: sha512-ZPsnLyrpDRmojKrBbJykASyLLVFkjyD+fWATeSuYgaqablijGOzxPxEKyrwUvNg+bgSQ7PkW2FTu65Xco19Gag==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.47':
+    resolution: {integrity: sha512-1XdgHDIPbARHuzZXM7ouzIbSUZFU9dTi9k+ryMhiZU4QCam4dvwOyUEFjEHNxAZehCYUIOmsSUZ2un6BIgUkWg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.51':
+    resolution: {integrity: sha512-f8sRTVyM+9BbzQKPlUP9dVVpgNEu65jFckNAAGzRfCrlaSi5AWUbCKEHIMcIYokv8pWblSKEqHkqKYZtwINnhw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.50':
+    resolution: {integrity: sha512-NHHsKoMhw6UylSU0XDnDc87+IQW8tRBTIe6vnOX12GSIlBDtoce6bSzONleIglCyu8d3H9bmTSfk+sIN5yh3WA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.53':
+    resolution: {integrity: sha512-z/JJ8Qvf2GiTn4bw+x8k7wQjxmPpNsiwZ7ls/h1cZHikrSpS0+65lB+lafnXZlxv1lqH4k6rQwh+2UsycC662g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.45':
+    resolution: {integrity: sha512-QMJXjTGLmHE4Ie03T5H4hHOLfcvMc9DaODO6b5dgte3S8ECf5bBuHUJW4cQREcYZyRkOU8iymqtiBxqF4icxZg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.50':
+    resolution: {integrity: sha512-pQ9ww4G53gwHlon1NMz25JhaBo13E9Jv+VVgjh39C/yzvby+xhSnEOb+VDYShKNCh1TbttMF/5CFCHkZrIqOcA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.50':
+    resolution: {integrity: sha512-9DbaPaT2aMbz18wtSpq9HVBErjBQwxykqTFgG6n8Bn05GN68mITz+G1869ekYx0mVT/BDjETj5czz/3cPgLwxA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.28':
+    resolution: {integrity: sha512-XkHArJreL8hnpKrBTlnwrIcynZT4kDiAF6BF/z7AVxV7VUvojrjL2RzeK8QLVNyfzkEJGIYBKoufOIOSSpd6nQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.49':
+    resolution: {integrity: sha512-9CQoJfMZMqGJVBqFO/C8Gwke6WM7CLskQBiAjGU5LyXsVtqhymAATfqFnIa87Dw23ssfgGzqBHpSSwSchldFXw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.18':
+    resolution: {integrity: sha512-xBWrodBvW5SHCZV11UZUJG0pSHkLCEREIBoNbff1C1sacOUCmxJnTCPE80sCGLCtqgXg98I2MQJe2z28tcZSsw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.33':
+    resolution: {integrity: sha512-Hn0RThJEbyOZWV2PV9Z4YD3nitGPxybmyU17dSe9b61WOBcKnqS0WTtM3c1zyZq9WnGiyrfi/i+UBPUk7cM8Ug==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1064.0':
+    resolution: {integrity: sha512-sjI+iA4JtgeckBgKwPQF7KzWillRoNDmtpiM0TRa0syiAKFHKUSf84kPXSO3+gA7aMMSxrcxzOM2oPSecaJvEA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.12':
+    resolution: {integrity: sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.7':
+    resolution: {integrity: sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.29':
+    resolution: {integrity: sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -693,6 +799,9 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@nodable/entities@2.1.1':
+    resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
+
   '@node-rs/argon2-android-arm-eabi@2.0.2':
     resolution: {integrity: sha512-DV/H8p/jt40lrao5z5g6nM9dPNPGEHL+aK6Iy/og+dbL503Uj0AHLqj1Hk9aVUSCNnsDdUEKp4TVMi0YakDYKw==}
     engines: {node: '>= 10'}
@@ -1129,6 +1238,42 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@smithy/core@3.24.6':
+    resolution: {integrity: sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.8':
+    resolution: {integrity: sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.6':
+    resolution: {integrity: sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.7':
+    resolution: {integrity: sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.6':
+    resolution: {integrity: sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.3':
+    resolution: {integrity: sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1504,6 +1649,9 @@ packages:
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
@@ -1949,6 +2097,13 @@ packages:
 
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
+    hasBin: true
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2663,6 +2818,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -3176,6 +3335,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
   sugarss@5.0.1:
     resolution: {integrity: sha512-ctS5RYCBVvPoZAnzIaX5QSShK8ZiZxD5HUqSxlusvEMC+QZQIPCPOIJg6aceFX+K2rf4+SH89eu++h1Zmsr2nw==}
     engines: {node: '>=18.0'}
@@ -3539,6 +3701,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -3581,6 +3747,236 @@ packages:
         optional: true
 
 snapshots:
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.12
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.12
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/util-locate-window': 3.965.7
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/util-locate-window': 3.965.7
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.12
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.12
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/checksums@3.1000.3':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1064.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/credential-provider-node': 3.972.53
+      '@aws-sdk/middleware-flexible-checksums': 3.974.28
+      '@aws-sdk/middleware-sdk-s3': 3.972.49
+      '@aws-sdk/signature-v4-multi-region': 3.996.33
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.19':
+    dependencies:
+      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/xml-builder': 3.972.29
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.6
+      '@smithy/signature-v4': 5.4.6
+      '@smithy/types': 4.14.3
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.47':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.51':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/credential-provider-env': 3.972.45
+      '@aws-sdk/credential-provider-http': 3.972.47
+      '@aws-sdk/credential-provider-login': 3.972.50
+      '@aws-sdk/credential-provider-process': 3.972.45
+      '@aws-sdk/credential-provider-sso': 3.972.50
+      '@aws-sdk/credential-provider-web-identity': 3.972.50
+      '@aws-sdk/nested-clients': 3.997.18
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/credential-provider-imds': 4.3.8
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.50':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/nested-clients': 3.997.18
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.53':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.45
+      '@aws-sdk/credential-provider-http': 3.972.47
+      '@aws-sdk/credential-provider-ini': 3.972.51
+      '@aws-sdk/credential-provider-process': 3.972.45
+      '@aws-sdk/credential-provider-sso': 3.972.50
+      '@aws-sdk/credential-provider-web-identity': 3.972.50
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/credential-provider-imds': 4.3.8
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.50':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/nested-clients': 3.997.18
+      '@aws-sdk/token-providers': 3.1064.0
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.50':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/nested-clients': 3.997.18
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.28':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.3
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/signature-v4-multi-region': 3.996.33
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.18':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/signature-v4-multi-region': 3.996.33
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.33':
+    dependencies:
+      '@aws-sdk/types': 3.973.12
+      '@smithy/signature-v4': 5.4.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1064.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.19
+      '@aws-sdk/nested-clients': 3.997.18
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.12':
+    dependencies:
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.7':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.29':
+    dependencies:
+      '@smithy/types': 4.14.3
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -4004,6 +4400,8 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@nodable/entities@2.1.1': {}
+
   '@node-rs/argon2-android-arm-eabi@2.0.2':
     optional: true
 
@@ -4339,6 +4737,54 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
+
+  '@smithy/core@3.24.6':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.8':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.6':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.7':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.6':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4805,6 +5251,8 @@ snapshots:
       type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.15:
     dependencies:
@@ -5368,6 +5816,18 @@ snapshots:
   fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.2: {}
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.1
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -6041,6 +6501,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
@@ -6611,6 +7073,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strnum@2.3.0: {}
+
   sugarss@5.0.1(postcss@8.5.15):
     dependencies:
       postcss: 8.5.15
@@ -6936,6 +7400,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.0: {}
+
+  xml-naming@0.1.0: {}
 
   xtend@4.0.2: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -28,6 +28,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.658.1",
     "@elastic/elasticsearch": "^8.19.1",
     "@node-rs/argon2": "^2.0.2",
     "@prisma/adapter-pg": "^7.8.0",

--- a/server/src/storage/s3Storage.ts
+++ b/server/src/storage/s3Storage.ts
@@ -1,36 +1,109 @@
-import { Storage, StoredFile } from './types.js';
+import { randomUUID } from 'node:crypto';
 
-// Placeholder for the eventual S3 backend. The whole point of the Storage seam is
-// that turning this on is self-contained: implement the two methods below, add
-// the SDK, and set STORAGE_DRIVER=s3 (see ./index.ts). Nothing else changes.
+import { ALLOWED_UPLOAD_TYPES, Storage, StoredFile } from './types.js';
+
+// S3 backend, enabled with STORAGE_DRIVER=s3. Works against real S3 or any
+// S3-compatible store (Cloudflare R2, MinIO, Backblaze B2) via S3_ENDPOINT.
 //
-// Sketch of the real implementation:
+// The AWS SDK is imported lazily (see `sdk()`), so a disk-only deploy never loads
+// it — keeping the common, cheap path free of the dependency's startup cost.
+// Credentials come from the standard AWS chain (env vars, shared config, or the
+// instance/task IAM role); never hard-code them here.
 //
-//   import { S3Client, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
-//   const client = new S3Client({ region: process.env.AWS_REGION });
-//   async save(buffer, contentType) {
-//     const ext = ALLOWED_IMAGE_TYPES[contentType];
-//     const key = `${randomUUID()}.${ext}`;
-//     await client.send(new PutObjectCommand({
-//       Bucket: this.bucket, Key: key, Body: buffer, ContentType: contentType,
-//     }));
-//     return { key, url: `${this.cdnBase}/${key}` };  // CloudFront/bucket URL
-//   }
-//   async delete(key) {
-//     await client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: key }));
-//   }
-//
-// Stored as a class (not a TODO comment in the controller) precisely so the read
-// path — which only sees the returned `url` — never needs to know which backend ran.
+// Config:
+//   S3_BUCKET            (required) target bucket
+//   AWS_REGION           bucket region (default us-east-1 for URL construction)
+//   S3_CDN_URL           public base URL of a CDN in front of the bucket
+//                        (e.g. https://dxxxx.cloudfront.net); falls back to the
+//                        bucket's own URL when unset
+//   S3_KEY_PREFIX        optional "folder" within the bucket (e.g. "media")
+//   S3_ENDPOINT          custom endpoint for S3-compatible stores
+//   S3_FORCE_PATH_STYLE  "true" for stores that need path-style URLs (MinIO)
 export class S3Storage implements Storage {
-  save(): Promise<StoredFile> {
-    throw new Error(
-      'S3Storage is not implemented yet. Install @aws-sdk/client-s3 and fill in s3Storage.ts, ' +
-        'or keep STORAGE_DRIVER=disk.',
-    );
+  private readonly bucket: string;
+  private readonly region: string | undefined;
+  private readonly endpoint: string | undefined;
+  private readonly forcePathStyle: boolean;
+  /** Public base URL the client loads media from (CDN or bucket). No trailing slash. */
+  private readonly publicBase: string;
+  /** Optional key prefix within the bucket, normalized to "" or "dir/". */
+  private readonly keyPrefix: string;
+
+  // Lazily-created client + commands, resolved on first use.
+  private sdkPromise?: Promise<{
+    client: import('@aws-sdk/client-s3').S3Client;
+    PutObjectCommand: typeof import('@aws-sdk/client-s3').PutObjectCommand;
+    DeleteObjectCommand: typeof import('@aws-sdk/client-s3').DeleteObjectCommand;
+  }>;
+
+  constructor() {
+    const bucket = process.env.S3_BUCKET;
+    if (!bucket) {
+      throw new Error('STORAGE_DRIVER=s3 requires S3_BUCKET to be set.');
+    }
+    this.bucket = bucket;
+    this.region = process.env.AWS_REGION;
+    this.endpoint = process.env.S3_ENDPOINT;
+    this.forcePathStyle = process.env.S3_FORCE_PATH_STYLE === 'true';
+    this.keyPrefix = normalizePrefix(process.env.S3_KEY_PREFIX);
+
+    const cdn = process.env.S3_CDN_URL;
+    if (cdn) {
+      this.publicBase = stripTrailingSlash(cdn);
+    } else if (this.endpoint) {
+      this.publicBase = `${stripTrailingSlash(this.endpoint)}/${bucket}`;
+    } else {
+      this.publicBase = `https://${bucket}.s3.${this.region ?? 'us-east-1'}.amazonaws.com`;
+    }
   }
 
-  delete(): Promise<void> {
-    throw new Error('S3Storage is not implemented yet.');
+  private async sdk() {
+    this.sdkPromise ??= import('@aws-sdk/client-s3').then(
+      ({ S3Client, PutObjectCommand, DeleteObjectCommand }) => ({
+        client: new S3Client({
+          region: this.region,
+          endpoint: this.endpoint,
+          forcePathStyle: this.forcePathStyle,
+        }),
+        PutObjectCommand,
+        DeleteObjectCommand,
+      }),
+    );
+    return this.sdkPromise;
   }
+
+  async save(buffer: Buffer, contentType: string): Promise<StoredFile> {
+    const ext = ALLOWED_UPLOAD_TYPES[contentType];
+    if (!ext) throw new Error(`Unsupported upload type: ${contentType}`);
+
+    const { client, PutObjectCommand } = await this.sdk();
+    const key = `${this.keyPrefix}${randomUUID()}.${ext}`;
+    await client.send(
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+        Body: buffer,
+        ContentType: contentType,
+        // Keys are immutable (a fresh UUID per upload), so cache hard at the CDN/edge.
+        CacheControl: 'public, max-age=31536000, immutable',
+      }),
+    );
+
+    return { key, url: `${this.publicBase}/${key}` };
+  }
+
+  async delete(key: string): Promise<void> {
+    const { client, DeleteObjectCommand } = await this.sdk();
+    await client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: key }));
+  }
+}
+
+function stripTrailingSlash(s: string): string {
+  return s.endsWith('/') ? s.slice(0, -1) : s;
+}
+
+function normalizePrefix(prefix: string | undefined): string {
+  if (!prefix) return '';
+  const trimmed = prefix.replace(/^\/+/, '').replace(/\/+$/, '');
+  return trimmed ? `${trimmed}/` : '';
 }

--- a/server/src/test/s3Storage.test.ts
+++ b/server/src/test/s3Storage.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the AWS SDK so the S3 backend can be exercised without a bucket or network.
+// vi.mock is hoisted and applies to S3Storage's lazy `import('@aws-sdk/client-s3')`.
+const sendMock = vi.fn<(cmd: unknown) => Promise<void>>();
+const clientConfigs: unknown[] = [];
+
+vi.mock('@aws-sdk/client-s3', () => {
+  class S3Client {
+    constructor(config: unknown) {
+      clientConfigs.push(config);
+    }
+    send = sendMock;
+  }
+  class PutObjectCommand {
+    readonly type = 'put';
+    constructor(public input: Record<string, unknown>) {}
+  }
+  class DeleteObjectCommand {
+    readonly type = 'delete';
+    constructor(public input: Record<string, unknown>) {}
+  }
+  return { S3Client, PutObjectCommand, DeleteObjectCommand };
+});
+
+import { S3Storage } from '../storage/s3Storage.js';
+
+const UUID_RE = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+
+// Set only the S3_* / AWS_* vars a test needs; clear the rest so cases don't leak.
+function setEnv(vars: Record<string, string | undefined>) {
+  for (const key of [
+    'S3_BUCKET',
+    'AWS_REGION',
+    'S3_CDN_URL',
+    'S3_KEY_PREFIX',
+    'S3_ENDPOINT',
+    'S3_FORCE_PATH_STYLE',
+  ]) {
+    delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(vars)) {
+    if (value !== undefined) process.env[key] = value;
+  }
+}
+
+beforeEach(() => {
+  sendMock.mockReset();
+  sendMock.mockResolvedValue(undefined);
+  clientConfigs.length = 0;
+});
+
+describe('S3Storage', () => {
+  it('requires S3_BUCKET', () => {
+    setEnv({});
+    expect(() => new S3Storage()).toThrow(/S3_BUCKET/);
+  });
+
+  it('rejects unsupported content types', async () => {
+    setEnv({ S3_BUCKET: 'owl-media' });
+    await expect(
+      new S3Storage().save(Buffer.from('x'), 'application/zip'),
+    ).rejects.toThrow(/Unsupported upload type/);
+  });
+
+  it('PutObjects the buffer under a uuid key and returns the bucket URL', async () => {
+    setEnv({ S3_BUCKET: 'owl-media', AWS_REGION: 'eu-west-1' });
+    const body = Buffer.from('imagebytes');
+
+    const { key, url } = await new S3Storage().save(body, 'image/png');
+
+    expect(key).toMatch(new RegExp(`^${UUID_RE}\\.png$`));
+    expect(url).toBe(`https://owl-media.s3.eu-west-1.amazonaws.com/${key}`);
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const cmd = sendMock.mock.calls[0][0] as { type: string; input: Record<string, unknown> };
+    expect(cmd.type).toBe('put');
+    expect(cmd.input).toMatchObject({
+      Bucket: 'owl-media',
+      Key: key,
+      Body: body,
+      ContentType: 'image/png',
+      CacheControl: 'public, max-age=31536000, immutable',
+    });
+  });
+
+  it('defaults the region to us-east-1 for URL construction', async () => {
+    setEnv({ S3_BUCKET: 'owl-media' });
+    const { key, url } = await new S3Storage().save(Buffer.from('x'), 'image/jpeg');
+    expect(key).toMatch(/\.jpg$/);
+    expect(url).toBe(`https://owl-media.s3.us-east-1.amazonaws.com/${key}`);
+  });
+
+  it('prefers the CDN base URL when S3_CDN_URL is set', async () => {
+    setEnv({
+      S3_BUCKET: 'owl-media',
+      AWS_REGION: 'eu-west-1',
+      S3_CDN_URL: 'https://cdn.example.com/', // trailing slash should be trimmed
+    });
+    const { key, url } = await new S3Storage().save(Buffer.from('x'), 'image/webp');
+    expect(url).toBe(`https://cdn.example.com/${key}`);
+  });
+
+  it('applies a key prefix and uses a custom endpoint URL', async () => {
+    setEnv({
+      S3_BUCKET: 'owl-media',
+      S3_ENDPOINT: 'https://r2.example.com',
+      S3_KEY_PREFIX: '/media/', // leading/trailing slashes normalized
+      S3_FORCE_PATH_STYLE: 'true',
+    });
+    const { key, url } = await new S3Storage().save(Buffer.from('x'), 'video/mp4');
+
+    expect(key).toMatch(new RegExp(`^media/${UUID_RE}\\.mp4$`));
+    expect(url).toBe(`https://r2.example.com/owl-media/${key}`);
+    expect(clientConfigs[0]).toMatchObject({
+      endpoint: 'https://r2.example.com',
+      forcePathStyle: true,
+    });
+  });
+
+  it('DeleteObjects by key', async () => {
+    setEnv({ S3_BUCKET: 'owl-media' });
+    await new S3Storage().delete('media/abc.png');
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const cmd = sendMock.mock.calls[0][0] as { type: string; input: Record<string, unknown> };
+    expect(cmd.type).toBe('delete');
+    expect(cmd.input).toMatchObject({ Bucket: 'owl-media', Key: 'media/abc.png' });
+  });
+});


### PR DESCRIPTION
## What

Implements the `S3Storage` backend behind the existing `Storage` seam — previously a documented placeholder. `STORAGE_DRIVER=s3` is now a real, working backend; disk stays the default, so nothing changes for existing deploys.

## Details

- `save()` / `delete()` issue `PutObject` / `DeleteObject` via `@aws-sdk/client-s3`. Objects are stored under a UUID key with the content-type's extension and a long-lived immutable `Cache-Control` (keys never change, so they're safe to cache at the edge forever).
- The AWS SDK is imported lazily, so disk-only deploys never load it — confirmed by the build, where the storage code splits into its own chunk and the SDK stays out of the main server bundle.
- Public URLs use `S3_CDN_URL` (e.g. a CloudFront distribution) when set, otherwise fall back to the bucket's own URL — so putting a CDN in front is just an env var.
- Works against S3-compatible stores (Cloudflare R2, etc.) via `S3_ENDPOINT` / `S3_FORCE_PATH_STYLE`, with an optional `S3_KEY_PREFIX` for a bucket "folder".
- Credentials come from the standard AWS chain (env vars, shared config, or the instance/task IAM role) — never read or stored by the app.
- Nothing else changed: controllers, client, and seed only ever see the returned `url` and don't know which backend ran.

## Tests

Adds `server/src/test/s3Storage.test.ts` — 7 cases with the AWS SDK mocked, so it runs with no bucket or network: config validation (`S3_BUCKET` required), content-type guard, key/URL construction across the bucket / default-region / CDN / custom-endpoint branches, key-prefix normalization, and the `PutObject` / `DeleteObject` calls. `pnpm typecheck`, `eslint`, and `pnpm build` all pass.

## Docs

Updates `docs/storage.md` to describe S3 as implemented and document the full `S3_*` env reference. (The README — which also reflects this — was rewritten separately on `main`.)